### PR TITLE
SCRUM-33 / 선호 정보 편집(운동시설,운동시간,운동종류) 및 QA 반영

### DIFF
--- a/app/mate/_components/ExploreMate/ExploreMate.tsx
+++ b/app/mate/_components/ExploreMate/ExploreMate.tsx
@@ -1,8 +1,10 @@
 "use client";
 import AfternoonIcon from "@/assets/images/afternoon.svg";
 import ChevronLeft from "@/assets/images/chevron-left.svg";
+import CircleXIcon from "@/assets/images/circle-x.svg";
 import EveningIcon from "@/assets/images/evening.svg";
 import MorningIcon from "@/assets/images/morning.svg";
+import SearchIcon from "@/assets/images/search.svg";
 import { Typography } from "@/components/atoms/Typography";
 import Tooltip from "@/components/common/Tooltip/Tooltip";
 import { TIME_MAPPING } from "@/constants/Time";
@@ -129,57 +131,71 @@ export default function ExploreMate() {
         />
       )}
 
-      {/* 실제 메이트 리스트 */}
-      <S.MateList>
-        {mates.map((mate) => {
-          const timeSlot = getTimeSlot(mate.preferredWorkoutTime);
+      {mates.length === 0 ? (
+        <S.EmptyWrapper>
+          <S.IconWrapper>
+            <SearchIcon className="search-icon" />
+            <CircleXIcon className="circle-x-icon" />
+          </S.IconWrapper>
+          <Typography.H4Sb color="#8A92A3">
+            해당하는 메이트가 없어요
+          </Typography.H4Sb>
+        </S.EmptyWrapper>
+      ) : (
+        <S.MateList>
+          {mates.map((mate) => {
+            const timeSlot = getTimeSlot(mate.preferredWorkoutTime);
 
-          return (
-            <S.MateListItem
-              key={mate.id}
-              onClick={() =>
-                router.push(`/mate/mateprofile/${encodeURIComponent(mate.id)}`)
-              }
-            >
-              <S.MateProfileImageWrapper>
-                <S.ProfileImage src={mate.profileUrl} alt={mate.nickname} />
-              </S.MateProfileImageWrapper>
-              <S.MateInfoWrapper>
-                <S.ProfileInfo>
-                  <S.ProfileInfoTitle>
-                    <Typography.H3Sb>{mate.nickname}</Typography.H3Sb>
-                    <Typography.H6Md color="#6C727F">
-                      {mate.gender === "F" ? "여" : "남"}, {mate.age}세
-                    </Typography.H6Md>
-                  </S.ProfileInfoTitle>
-                  <S.ProfileText>
-                    <Typography.H6Md color="#8A92A3">
-                      {mate.introduction}
-                    </Typography.H6Md>
-                  </S.ProfileText>
-                </S.ProfileInfo>
-                <S.PreferenceTags>
-                  {mate.favoriteWorkouts.map((workout) => (
-                    <S.Tag key={workout.code}>
+            return (
+              <S.MateListItem
+                key={mate.id}
+                onClick={() =>
+                  router.push(
+                    `/mate/mateprofile/${encodeURIComponent(mate.id)}`,
+                  )
+                }
+              >
+                <S.MateProfileImageWrapper>
+                  <S.ProfileImage src={mate.profileUrl} alt={mate.nickname} />
+                </S.MateProfileImageWrapper>
+                <S.MateInfoWrapper>
+                  <S.ProfileInfo>
+                    <S.ProfileInfoTitle>
+                      <Typography.H3Sb>{mate.nickname}</Typography.H3Sb>
+                      <Typography.H6Md color="#6C727F">
+                        {mate.gender === "F" ? "여" : "남"}, {mate.age}세
+                      </Typography.H6Md>
+                    </S.ProfileInfoTitle>
+                    <S.ProfileText>
+                      <Typography.H6Md color="#8A92A3">
+                        {mate.introduction}
+                      </Typography.H6Md>
+                    </S.ProfileText>
+                  </S.ProfileInfo>
+                  <S.PreferenceTags>
+                    {mate.favoriteWorkouts.map((workout) => (
+                      <S.Tag key={workout.code}>
+                        <Typography.H7Md color="#6C727F">
+                          {workout.name}
+                        </Typography.H7Md>
+                      </S.Tag>
+                    ))}
+
+                    <S.TimeTag>
+                      {timeSlot &&
+                        iconMapping[timeSlot] &&
+                        iconMapping[timeSlot]}
                       <Typography.H7Md color="#6C727F">
-                        {workout.name}
+                        {TIME_MAPPING[mate.preferredWorkoutTime]}
                       </Typography.H7Md>
-                    </S.Tag>
-                  ))}
-
-                  <S.TimeTag>
-                    {timeSlot && iconMapping[timeSlot] && iconMapping[timeSlot]}
-
-                    <Typography.H7Md color="#6C727F">
-                      {TIME_MAPPING[mate.preferredWorkoutTime]}
-                    </Typography.H7Md>
-                  </S.TimeTag>
-                </S.PreferenceTags>
-              </S.MateInfoWrapper>
-            </S.MateListItem>
-          );
-        })}
-      </S.MateList>
+                    </S.TimeTag>
+                  </S.PreferenceTags>
+                </S.MateInfoWrapper>
+              </S.MateListItem>
+            );
+          })}
+        </S.MateList>
+      )}
 
       <div ref={loadMoreRef} style={{ height: 1 }} />
     </S.ExploreMateContainer>

--- a/app/mate/_components/ExploreMate/FilterPanel/FilterPanel.tsx
+++ b/app/mate/_components/ExploreMate/FilterPanel/FilterPanel.tsx
@@ -41,7 +41,7 @@ export default function FilterPanel({ onClose, onApply }: FilterPanelProps) {
 
   useEffect(() => {
     setIsApplyEnabled(
-      !!selectedGender && !!selectedTime && selectedSports.length > 0,
+      !!selectedGender || !!selectedTime || selectedSports.length > 0,
     );
   }, [selectedGender, selectedTime, selectedSports]);
 

--- a/app/mate/_components/ExploreMate/style.ts
+++ b/app/mate/_components/ExploreMate/style.ts
@@ -235,7 +235,7 @@ export const IconWrapper = styled.div`
   .circle-x-icon {
     position: absolute;
 
-    top: -2px;
+    top: -1px;
     left: 20px;
     width: 18px;
     height: 18px;

--- a/app/mate/_components/ExploreMate/style.ts
+++ b/app/mate/_components/ExploreMate/style.ts
@@ -4,6 +4,8 @@ import { COLORS } from "@/constants/Theme";
 import { styled } from "styled-components";
 
 export const ExploreMateContainer = styled.div`
+  position: relative;
+
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
@@ -191,4 +193,52 @@ export const ProfileImage = styled.img`
   border-radius: 50%;
 
   background-color: ${COLORS.GRAYSCALE_300};
+`;
+
+export const EmptyWrapper = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+
+  width: 153px;
+  height: 73px;
+
+  & > svg {
+    width: 40px;
+    height: 40px;
+  }
+
+  align-items: center;
+`;
+
+export const IconWrapper = styled.div`
+  position: relative;
+  width: 40px;
+  height: 40px;
+
+  .search-icon {
+    position: absolute;
+    top: 0;
+    left: 0;
+
+    width: 40px;
+    height: 40px;
+    stroke: #dce0ea;
+  }
+
+  .circle-x-icon {
+    position: absolute;
+
+    top: -2px;
+    left: 20px;
+    width: 18px;
+    height: 18px;
+    stroke: #dce0ea;
+  }
 `;

--- a/app/mate/facility/style.ts
+++ b/app/mate/facility/style.ts
@@ -17,6 +17,7 @@ export const facilityContainer2 = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
+  align-items: center;
 
   height: 100%;
 
@@ -66,8 +67,6 @@ export const ResultList = styled.div`
   align-items: flex-start;
 
   gap: 16px;
-
-  box-sizing: border-box;
 
   width: 100%;
   max-width: 450px;

--- a/app/mate/mateprofile/[mateId]/page.tsx
+++ b/app/mate/mateprofile/[mateId]/page.tsx
@@ -3,7 +3,10 @@
 import Modal from "@/app/mate/_components/Modal/Modal";
 import * as S from "@/app/mate/mateprofile/[mateId]/style";
 import AfternoonIcon from "@/assets/images/afternoon.svg";
-import Dumbbels from "@/assets/images/dumbbells.svg";
+import {
+  default as DumbbbelIcon,
+  default as Dumbbels,
+} from "@/assets/images/dumbbells.svg";
 import EveningIcon from "@/assets/images/evening.svg";
 import MorningIcon from "@/assets/images/morning.svg";
 import { Typography } from "@/components/atoms/Typography";
@@ -86,21 +89,31 @@ export default function MateProfile() {
       <S.PageContainer>
         <S.ProfileSection $isEditingProfile={isEditingProfile}>
           <S.ProfileOverviewWrapper>
-            <S.ProfileImageWrapper $isEditingProfile={isEditingProfile}>
-              <S.BackgroundImage
-                className="background-img"
-                src={data?.profileUrl}
-                alt={data?.nickname}
-              />
-            </S.ProfileImageWrapper>
+            <S.ProfileContainerWrapper>
+              <S.ProfileImageWrapper $isEditingProfile={isEditingProfile}>
+                <S.BackgroundImage
+                  className="background-img"
+                  src={data?.profileUrl}
+                  alt={data?.nickname}
+                />
+              </S.ProfileImageWrapper>
+              <S.DumbberIconWrapper>
+                <DumbbbelIcon color="#FFFFFF" />
+              </S.DumbberIconWrapper>
 
-            <S.ProfileName>{data?.nickname}</S.ProfileName>
-            <S.ProfileInfo>
-              {data?.gender === "F" ? "여" : "남"} · 만 {data?.age}세
-            </S.ProfileInfo>
-            <S.PrimaryButton>
-              {skillLevelMap[data?.skillLevel || ""] || "미정"}
-            </S.PrimaryButton>
+              <S.ProfileHeaderWrapper>
+                <S.ProfileNameInfoWrapper>
+                  <S.ProfileName>{data?.nickname}</S.ProfileName>
+                  <S.ProfileInfo>
+                    {data?.gender === "F" ? "여" : "남"} · 만 {data?.age}세
+                  </S.ProfileInfo>
+                </S.ProfileNameInfoWrapper>
+              </S.ProfileHeaderWrapper>
+              <S.PrimaryButton>
+                {skillLevelMap[data?.skillLevel || ""] || "미정"}
+              </S.PrimaryButton>
+            </S.ProfileContainerWrapper>
+
             <S.ProfileDescription>
               <S.DescriptionHeader>
                 <S.DescriptionTitle>간단 소개</S.DescriptionTitle>

--- a/app/mate/mateprofile/[mateId]/page.tsx
+++ b/app/mate/mateprofile/[mateId]/page.tsx
@@ -24,9 +24,9 @@ import { JSX, useState, useTransition } from "react";
 
 export default function MateProfile() {
   const skillLevelMap: Record<string, string> = {
-    BEGINNER: "운동 초보",
-    INTERMEDIATE: "운동 중수",
-    ADVANCED: "운동 고수",
+    BEGINNER: "운동초보",
+    INTERMEDIATE: "운동중수",
+    ADVANCED: "운동고수",
   };
 
   const iconMapping: Record<string, JSX.Element> = {
@@ -108,9 +108,9 @@ export default function MateProfile() {
                     {data?.gender === "F" ? "여" : "남"} · 만 {data?.age}세
                   </S.ProfileInfo>
                 </S.ProfileNameInfoWrapper>
-                <S.PrimaryButton>
+                <S.SkillLevelInfo>
                   {skillLevelMap[data?.skillLevel || ""] || "미정"}
-                </S.PrimaryButton>
+                </S.SkillLevelInfo>
               </S.ProfileHeaderWrapper>
             </S.ProfileContainerWrapper>
 

--- a/app/mate/mateprofile/[mateId]/page.tsx
+++ b/app/mate/mateprofile/[mateId]/page.tsx
@@ -157,13 +157,16 @@ export default function MateProfile() {
                 </S.PreferenceTitle>
               </S.PreferenceHeader>
               {data?.favoritePlaces.length === 0 && (
-                <S.NoPreferenceView>
-                  <Typography.H4Md>-</Typography.H4Md>
-                  <Typography.H5Md color="#8A92A3">
-                    선호하는 시설이 없어요.
-                  </Typography.H5Md>
-                </S.NoPreferenceView>
+                <S.PreferencePlaceWrapper>
+                  <S.NoPreferenceView>
+                    <Typography.H4Md>-</Typography.H4Md>
+                    <Typography.H5Md color="#8A92A3">
+                      선호하는 시설이 없어요.
+                    </Typography.H5Md>
+                  </S.NoPreferenceView>
+                </S.PreferencePlaceWrapper>
               )}
+
               <S.PreferencePlaceWrapper>
                 {data?.favoritePlaces.map((place) => (
                   <S.PreferencePlaceInfo key={place.placeName}>

--- a/app/mate/mateprofile/[mateId]/page.tsx
+++ b/app/mate/mateprofile/[mateId]/page.tsx
@@ -108,10 +108,10 @@ export default function MateProfile() {
                     {data?.gender === "F" ? "여" : "남"} · 만 {data?.age}세
                   </S.ProfileInfo>
                 </S.ProfileNameInfoWrapper>
+                <S.PrimaryButton>
+                  {skillLevelMap[data?.skillLevel || ""] || "미정"}
+                </S.PrimaryButton>
               </S.ProfileHeaderWrapper>
-              <S.PrimaryButton>
-                {skillLevelMap[data?.skillLevel || ""] || "미정"}
-              </S.PrimaryButton>
             </S.ProfileContainerWrapper>
 
             <S.ProfileDescription>

--- a/app/mate/mateprofile/[mateId]/page.tsx
+++ b/app/mate/mateprofile/[mateId]/page.tsx
@@ -15,17 +15,9 @@ import { TIME_MAPPING } from "@/constants/Time";
 import { TOAST_STATUSES } from "@/constants/Toast";
 import { useMateDetail } from "@/hooks/queries/useMateDetails";
 import { sendMateRequest } from "@/services/mate/sendMateRequest";
+import getTimeSlot from "@/utils/getTimeSlot";
 import { useParams } from "next/navigation";
 import { JSX, useState, useTransition } from "react";
-
-function getTimeSlot(
-  timeKey: string,
-): "morning" | "afternoon" | "evening" | "" {
-  if (timeKey.includes("MORNING")) return "morning";
-  if (timeKey.includes("AFTERNOON")) return "afternoon";
-  if (timeKey.includes("EVENING")) return "evening";
-  return "";
-}
 
 export default function MateProfile() {
   const skillLevelMap: Record<string, string> = {
@@ -138,7 +130,7 @@ export default function MateProfile() {
                 {data?.favoriteWorkouts.map((sport) => (
                   <S.PreferenceBadge key={sport.code}>
                     <Dumbbels color={"#004DFF"} />
-                    {sport.name}
+                    <Typography.H4Md>{sport.name}</Typography.H4Md>
                   </S.PreferenceBadge>
                 ))}
               </S.PreferenceContent>

--- a/app/mate/mateprofile/[mateId]/style.ts
+++ b/app/mate/mateprofile/[mateId]/style.ts
@@ -120,7 +120,7 @@ export const PreferenceFacilityWrapper = styled.div`
   gap: 12px;
 
   width: 100%;
-  height: 165px;
+  height: auto;
   min-height: 165px;
 
   padding: 28px 20px;
@@ -304,7 +304,8 @@ export const PreferenceBadge = styled.div`
 export const PreferencePlaceWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  width: 350px;
+  width: 100%;
+  max-width: 450px;
   height: auto;
 
   gap: 16px;

--- a/app/mate/mateprofile/[mateId]/style.ts
+++ b/app/mate/mateprofile/[mateId]/style.ts
@@ -402,24 +402,26 @@ export const PreferenceTimeRange = styled.span`
   color: ${COLORS.GRAYSCALE_600};
 `;
 
-export const PrimaryButton = styled.button`
+export const SkillLevelInfo = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
   padding: 8px 10px;
   width: auto;
   height: 34px;
 
+  box-sizing: border-box;
   font-size: 12px;
   font-weight: 600;
   line-height: 150%;
   letter-spacing: -0.12px;
 
-  box-sizing: border-box;
-
-  color: ${COLORS.BLUE_500};
+  color: #004dff;
 
   background-color: ${COLORS.BLUE_50};
   border: none;
   border-radius: 10px;
-  cursor: pointer;
 `;
 
 export const ButtonWrapper = styled.div`

--- a/app/mate/mateprofile/[mateId]/style.ts
+++ b/app/mate/mateprofile/[mateId]/style.ts
@@ -33,11 +33,36 @@ export const ProfileSection = styled.section<{ $isEditingProfile: boolean }>`
   background-color: #ffffff;
 `;
 
+export const ProfileContainerWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+`;
+
+export const ProfileHeaderWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const ProfileNameInfoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+`;
+
 export const ProfileImageWrapper = styled.div<{ $isEditingProfile: boolean }>`
   position: relative;
   width: 80px;
   height: 80px;
   border-radius: 50%;
+  border: 2px solid ${COLORS.GRAYSCALE_100};
 
   overflow: hidden;
 
@@ -91,13 +116,15 @@ export const ProfileInfo = styled.p`
 `;
 
 export const ProfileOverviewWrapper = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
 
   width: 100%;
-  height: 328px;
-  padding: 0px 20px;
+  height: auto;
+
+  padding: 0px 20px 20px 20px;
 
   box-sizing: border-box;
 `;
@@ -379,7 +406,6 @@ export const PrimaryButton = styled.button`
   padding: 8px 10px;
   width: auto;
   height: 34px;
-  margin-top: 16px;
 
   font-size: 12px;
   font-weight: 600;
@@ -491,4 +517,22 @@ export const Line = styled.div`
   height: 10px;
 
   background-color: ${COLORS.GRAYSCALE_50};
+`;
+
+export const DumbberIconWrapper = styled.div`
+  position: absolute;
+  top: 55px;
+  right: calc(50% - 38px);
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  background-color: #004dff;
+
+  width: 28px;
+  height: 28px;
+  z-index: 50;
+
+  border-radius: 50%;
 `;

--- a/app/mypage/_components/EditProfile.style.ts
+++ b/app/mypage/_components/EditProfile.style.ts
@@ -130,7 +130,11 @@ export const ProfileInfo = styled.p`
   color: #888888;
 `;
 
-export const PrimaryButton = styled.button`
+export const SkillLevelInfo = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
   padding: 8px 10px;
   width: 68px;
   height: 34px;
@@ -146,7 +150,6 @@ export const PrimaryButton = styled.button`
 
   border: none;
   border-radius: 10px;
-  cursor: pointer;
 `;
 
 export const ProfileDescription = styled.div`

--- a/app/mypage/_components/EditProfile.style.ts
+++ b/app/mypage/_components/EditProfile.style.ts
@@ -134,7 +134,6 @@ export const PrimaryButton = styled.button`
   padding: 8px 10px;
   width: 68px;
   height: 34px;
-  margin-top: 16px;
 
   font-size: 12px;
   font-weight: 600;

--- a/app/mypage/_components/EditProfile.style.ts
+++ b/app/mypage/_components/EditProfile.style.ts
@@ -21,6 +21,7 @@ export const PageContainer = styled.div`
 `;
 
 export const ProfileSection = styled.section<{ $isEditingProfile: boolean }>`
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -35,14 +36,38 @@ export const ProfileSection = styled.section<{ $isEditingProfile: boolean }>`
     props.$isEditingProfile ? "0px solid #F9F9FA" : "10px solid #F9F9FA"};
 `;
 
+export const ProfileContainerWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+`;
+
+export const ProfileHeaderWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const ProfileNameInfoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+`;
+
 export const ProfileOverviewWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
 
   width: 100%;
-  height: 328px;
-  padding: 0px 20px;
+  height: auto;
+  padding: 0px 20px 20px 20px;
   box-sizing: border-box;
 `;
 
@@ -51,7 +76,8 @@ export const ProfileImageWrapper = styled.div<{ $isEditingProfile: boolean }>`
   width: 72px;
   height: 72px;
   border-radius: 50%;
-  border: 1px solid gray;
+
+  border: 2px solid ${COLORS.GRAYSCALE_100};
   overflow: hidden;
   flex-shrink: 0;
 
@@ -132,7 +158,7 @@ export const ProfileDescription = styled.div`
   max-width: 450px;
   height: 102px;
 
-  margin: 29px 0px;
+  margin: 29px 0px 0px 0px;
 `;
 
 export const DescriptionHeader = styled.div`
@@ -221,4 +247,22 @@ export const Line = styled.div`
 
   height: 10px;
   background-color: ${COLORS.GRAYSCALE_50};
+`;
+
+export const DumbberIconWrapper = styled.div`
+  position: absolute;
+  top: 50px;
+  right: calc(50% - 38px);
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  background-color: #004dff;
+
+  width: 28px;
+  height: 28px;
+  z-index: 50;
+
+  border-radius: 50%;
 `;

--- a/app/mypage/_components/EditProfile.style.ts
+++ b/app/mypage/_components/EditProfile.style.ts
@@ -192,6 +192,9 @@ export const DescriptionContent = styled.textarea`
   line-height: 150%;
   letter-spacing: -0.13px;
 
+  font-family: inherit;
+  font-style: normal;
+
   outline: none;
   resize: none;
   background: transparent;

--- a/app/mypage/_components/EditProfile.tsx
+++ b/app/mypage/_components/EditProfile.tsx
@@ -118,9 +118,9 @@ export default function EditProfile({
                     {gender === "M" ? "남성" : "여성"} · 만 {age}세
                   </S.ProfileInfo>
                 </S.ProfileNameInfoWrapper>
-                <S.PrimaryButton>
+                <S.SkillLevelInfo>
                   {skillLevelMap[skillLevel || "BEGINNER"]}
-                </S.PrimaryButton>
+                </S.SkillLevelInfo>
               </S.ProfileHeaderWrapper>
             </S.ProfileContainerWrapper>
 

--- a/app/mypage/_components/EditProfile.tsx
+++ b/app/mypage/_components/EditProfile.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import DumbbbelIcon from "@/assets/images/dumbbells.svg";
 import Header from "@/components/common/Header/Header";
 import { updateUserProfile } from "@/services/updateUserProfile";
 import { useUserInfoStore } from "@/stores/userInfoStore";
@@ -64,20 +65,6 @@ export default function EditProfile({
     }
   };
 
-  const preferences = ["헬스", "필라테스"];
-  const places = [
-    {
-      id: 1,
-      name: "에이블짐 잠실점",
-      address: "서울 송파구 올림픽로35가길 11 지하1층 001호",
-    },
-    {
-      id: 2,
-      name: "에이블짐 홍대점",
-      address: "서울 마포구 양화로12길 34 2층 201호",
-    },
-  ];
-
   const skillLevelMap: Record<string, string> = {
     BEGINNER: "운동초보",
     INTERMEDIATE: "운동중수",
@@ -104,21 +91,38 @@ export default function EditProfile({
       <S.PageContainer>
         <S.ProfileSection $isEditingProfile={true}>
           <S.ProfileOverviewWrapper>
-            <S.ProfileImageWrapper
-              $isEditingProfile={true}
-              onClick={handleProfileImageClick}
-            >
-              <S.BackgroundImage
-                className="background-img"
-                src={profileImage}
-                alt="Profile"
-              />
-              <S.OverlayImage
-                className="overlay"
-                src="/image-2.svg"
-                alt="Gallery"
-              />
-            </S.ProfileImageWrapper>
+            <S.ProfileContainerWrapper>
+              <S.ProfileImageWrapper
+                $isEditingProfile={true}
+                onClick={handleProfileImageClick}
+              >
+                <S.BackgroundImage
+                  className="background-img"
+                  src={profileImage}
+                  alt="Profile"
+                />
+                <S.OverlayImage
+                  className="overlay"
+                  src="/image-2.svg"
+                  alt="Gallery"
+                />
+              </S.ProfileImageWrapper>
+              <S.DumbberIconWrapper>
+                <DumbbbelIcon color="#FFFFFF" />
+              </S.DumbberIconWrapper>
+
+              <S.ProfileHeaderWrapper>
+                <S.ProfileNameInfoWrapper>
+                  <S.ProfileName>{nickname}</S.ProfileName>
+                  <S.ProfileInfo>
+                    {gender === "M" ? "남성" : "여성"} · 만 {age}세
+                  </S.ProfileInfo>
+                </S.ProfileNameInfoWrapper>
+                <S.PrimaryButton>
+                  {skillLevelMap[skillLevel || "BEGINNER"]}
+                </S.PrimaryButton>
+              </S.ProfileHeaderWrapper>
+            </S.ProfileContainerWrapper>
 
             <input
               type="file"
@@ -128,13 +132,6 @@ export default function EditProfile({
               onChange={handleFileChange}
             />
 
-            <S.ProfileName>{nickname}</S.ProfileName>
-            <S.ProfileInfo>
-              {gender === "M" ? "남성" : "여성"} · 만 {age}세
-            </S.ProfileInfo>
-            <S.PrimaryButton>
-              {skillLevelMap[skillLevel || "BEGINNER"]}
-            </S.PrimaryButton>
             <S.ProfileDescription>
               <S.DescriptionHeader>
                 <S.DescriptionTitle>간단 소개</S.DescriptionTitle>

--- a/app/mypage/_components/EditProfile.tsx
+++ b/app/mypage/_components/EditProfile.tsx
@@ -156,10 +156,7 @@ export default function EditProfile({
             <S.Line />
             <Sports />
             <S.Line />
-            <Facility
-              selectedPreferenceFacility={selectedPreferenceFacility}
-              handleNavigate={() => handleNavigate(places[0])}
-            />
+            <Facility />
             <S.Line />
             <Time />
           </S.PreferenceContainer>

--- a/app/mypage/_components/EditProfile.tsx
+++ b/app/mypage/_components/EditProfile.tsx
@@ -77,14 +77,6 @@ export default function EditProfile({
     address: string;
   } | null>(null);
 
-  const handleNavigate = (facility: {
-    id: number;
-    name: string;
-    address: string;
-  }) => {
-    setSelectedPreferenceFacility(facility);
-  };
-
   return (
     <>
       <Header title="프로필 편집" onClick={handleEditProfile} />

--- a/app/mypage/_components/EditProfile.tsx
+++ b/app/mypage/_components/EditProfile.tsx
@@ -161,7 +161,7 @@ export default function EditProfile({
               handleNavigate={() => handleNavigate(places[0])}
             />
             <S.Line />
-            <Time preferences={preferences} />
+            <Time />
           </S.PreferenceContainer>
         </S.ProfileSection>
       </S.PageContainer>

--- a/app/mypage/_components/EditProfile.tsx
+++ b/app/mypage/_components/EditProfile.tsx
@@ -154,7 +154,7 @@ export default function EditProfile({
 
           <S.PreferenceContainer>
             <S.Line />
-            <Sports preferences={preferences} />
+            <Sports />
             <S.Line />
             <Facility
               selectedPreferenceFacility={selectedPreferenceFacility}

--- a/app/mypage/_components/ViewProfile.tsx
+++ b/app/mypage/_components/ViewProfile.tsx
@@ -67,9 +67,9 @@ export default function ViewProfile({
                   {gender === "M" ? "남성" : "여성"} · 만 {age}세
                 </S.ProfileInfo>
               </S.ProfileNameInfoWrapper>
-              <S.PrimaryButton>
+              <S.SkillLevelInfo>
                 {skillLevelMap[skillLevel || "BEGINNER"]}
-              </S.PrimaryButton>
+              </S.SkillLevelInfo>
             </S.ProfileHeaderWrapper>
           </S.ProfileContainerWrapper>
 

--- a/app/mypage/_components/ViewProfile.tsx
+++ b/app/mypage/_components/ViewProfile.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import ChevronRight from "@/assets/images/chevron-right.svg";
+import DumbbbelIcon from "@/assets/images/dumbbells.svg";
 import { Typography } from "@/components/atoms/Typography";
 import Header from "@/components/common/Header/Header";
 import Link from "next/link";
@@ -48,20 +49,30 @@ export default function ViewProfile({
       <Header />
       <S.PageContainer>
         <S.ProfileSection $isEditingProfile={false}>
-          <S.ProfileImageWrapper $isEditingProfile={false}>
-            <S.BackgroundImage
-              className="background-img"
-              src={profileImage}
-              alt="Profile"
-            />
-          </S.ProfileImageWrapper>
-          <S.ProfileName>{nickname}</S.ProfileName>
-          <S.ProfileInfo>
-            {gender === "M" ? "남성" : "여성"} · 만 {age}세
-          </S.ProfileInfo>
-          <S.PrimaryButton>
-            {skillLevelMap[skillLevel || "BEGINNER"]}
-          </S.PrimaryButton>
+          <S.ProfileContainerWrapper>
+            <S.ProfileImageWrapper $isEditingProfile={false}>
+              <S.BackgroundImage
+                className="background-img"
+                src={profileImage}
+                alt="Profile"
+              />
+            </S.ProfileImageWrapper>
+            <S.DumbberIconWrapper>
+              <DumbbbelIcon color="#FFFFFF" />
+            </S.DumbberIconWrapper>
+            <S.ProfileHeaderWrapper>
+              <S.ProfileNameInfoWrapper>
+                <S.ProfileName>{nickname}</S.ProfileName>
+                <S.ProfileInfo>
+                  {gender === "M" ? "남성" : "여성"} · 만 {age}세
+                </S.ProfileInfo>
+              </S.ProfileNameInfoWrapper>
+              <S.PrimaryButton>
+                {skillLevelMap[skillLevel || "BEGINNER"]}
+              </S.PrimaryButton>
+            </S.ProfileHeaderWrapper>
+          </S.ProfileContainerWrapper>
+
           <S.ButtonWrapper>
             <S.SecondaryButton onClick={handleEditProfile}>
               프로필 편집

--- a/app/mypage/_components/ViewProfile.tsx
+++ b/app/mypage/_components/ViewProfile.tsx
@@ -115,14 +115,23 @@ export default function ViewProfile({
               );
             })}
           </S.List>
-        </S.ManagementSection>
 
-        <S.InfoSection>
           <S.LinksWrapper>
-            <Link href="/terms">이용약관</Link>
-            <Link href="/privacy">개인정보 처리방침</Link>
+            <Link href="/terms">
+              <S.UnderlinedWrapper>
+                <Typography.H6Md color="#ADB3C2">이용약관</Typography.H6Md>
+              </S.UnderlinedWrapper>
+            </Link>
+            <Link href="/privacy">
+              <S.UnderlinedWrapper>
+                {" "}
+                <Typography.H6Md color="#ADB3C2">
+                  개인정보 처리방침
+                </Typography.H6Md>
+              </S.UnderlinedWrapper>
+            </Link>
           </S.LinksWrapper>
-        </S.InfoSection>
+        </S.ManagementSection>
       </S.PageContainer>
     </>
   );

--- a/app/mypage/facility/Facility.tsx
+++ b/app/mypage/facility/Facility.tsx
@@ -1,13 +1,18 @@
 "use client";
 
 import { Typography } from "@/components/atoms/Typography";
+import { useMyPageInfo } from "@/hooks/queries/useMypageInfo";
 import Link from "next/link";
-import { useState } from "react";
 import * as S from "./style";
 
+interface placeInfoProps {
+  placeName: string;
+  address: string;
+}
+
 export default function Facility() {
-  const [selectedPreferenceFacilities, setSelectedPreferenceFacilities] =
-    useState([]);
+  const { data: userInfo } = useMyPageInfo();
+  const favoritePlaces = userInfo?.favoritePlaces ?? [];
 
   return (
     <>
@@ -16,7 +21,7 @@ export default function Facility() {
           <S.PreferenceTitle>
             선호 운동 시설
             <Typography.H3Bd style={{ marginLeft: "4px", color: "#004DFF" }}>
-              {selectedPreferenceFacilities.length}
+              {favoritePlaces.length}
             </Typography.H3Bd>
           </S.PreferenceTitle>
           <Link href="/mypage/facility">
@@ -24,9 +29,22 @@ export default function Facility() {
           </Link>
         </S.PreferenceHeader>
         <S.PreferencePlaceWrapper2>
-          <Typography.H4Md color="#8A92A3">
-            아직 선택한 시설이 없습니다.
-          </Typography.H4Md>
+          {favoritePlaces.length > 0 ? (
+            favoritePlaces.map((place: placeInfoProps) => (
+              <S.PreferencePlaceItem key={place.placeName}>
+                <Typography.H4Sb color="#27282D">
+                  {place.placeName}
+                </Typography.H4Sb>
+                <Typography.H6Md color="#8A92A3">
+                  {place.address}
+                </Typography.H6Md>
+              </S.PreferencePlaceItem>
+            ))
+          ) : (
+            <Typography.H4Md color="#8A92A3">
+              아직 선택한 시설이 없습니다.
+            </Typography.H4Md>
+          )}
         </S.PreferencePlaceWrapper2>
       </S.PreferenceFacilityWrapper>
     </>

--- a/app/mypage/facility/Facility.tsx
+++ b/app/mypage/facility/Facility.tsx
@@ -2,46 +2,12 @@
 
 import { Typography } from "@/components/atoms/Typography";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import * as S from "./style";
 
-interface FacilityData {
-  id: number;
-  name: string;
-  address: string;
-}
-
-interface FacilityProps {
-  selectedPreferenceFacility: FacilityData | null;
-  handleNavigate: (facility: FacilityData) => void;
-}
-
-export default function Facility({
-  selectedPreferenceFacility,
-  handleNavigate,
-}: FacilityProps) {
+export default function Facility() {
   const [selectedPreferenceFacilities, setSelectedPreferenceFacilities] =
-    useState<FacilityData[]>([
-      {
-        id: 1,
-        name: "에이블짐 잠실점",
-        address: "서울 송파구 올림픽로35가길 11 지하1층 001호",
-      },
-      {
-        id: 2,
-        name: "에이블짐 홍대점",
-        address: "서울 마포구 양화로12길 34 2층 201호",
-      },
-    ]);
-
-  useEffect(() => {
-    const storedFacilities = localStorage.getItem(
-      "selectedPreferenceFacilities",
-    );
-    if (storedFacilities) {
-      setSelectedPreferenceFacilities(JSON.parse(storedFacilities));
-    }
-  }, []);
+    useState([]);
 
   return (
     <>
@@ -58,20 +24,9 @@ export default function Facility({
           </Link>
         </S.PreferenceHeader>
         <S.PreferencePlaceWrapper2>
-          {selectedPreferenceFacilities.length > 0 ? (
-            selectedPreferenceFacilities.map((facility) => (
-              <S.PreferencePlaceInfo key={facility.id}>
-                <S.PreferencePlaceName>{facility.name}</S.PreferencePlaceName>
-                <S.PreferencePlaceAddress>
-                  {facility.address}
-                </S.PreferencePlaceAddress>
-              </S.PreferencePlaceInfo>
-            ))
-          ) : (
-            <Typography.H4Md color="#8A92A3">
-              아직 선택한 시설이 없습니다.
-            </Typography.H4Md>
-          )}
+          <Typography.H4Md color="#8A92A3">
+            아직 선택한 시설이 없습니다.
+          </Typography.H4Md>
         </S.PreferencePlaceWrapper2>
       </S.PreferenceFacilityWrapper>
     </>

--- a/app/mypage/facility/FacilitySearch.tsx
+++ b/app/mypage/facility/FacilitySearch.tsx
@@ -1,44 +1,22 @@
 "use client";
 
+import * as S from "@/app/mate/facility/style";
 import LogoumbbellsIcon from "@/assets/images/LogoDumbbells.svg";
-import Placeholder from "@/components/common/Placeholder/Placeholder";
 import { Typography } from "@/components/atoms/Typography";
 import Button from "@/components/common/Button";
-import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import Placeholder from "@/components/common/Placeholder/Placeholder";
+import { usePlacesSearch } from "@/hooks/queries/usePlacesSearch";
 import { Container } from "@mui/material";
-import * as S from "@/app/mate/facility/style";
-import * as MS from "./style";
 import Link from "next/link";
-
-const dummy2Facilities = [
-  {
-    id: 1,
-    name: "아워핏짐 잠실",
-    address: "서울 송파구 올림픽로35가길 11 지하1층 001호",
-  },
-  { id: 2, name: "아워핏짐 강남", address: "서울 강남구 강남대로 123" },
-  {
-    id: 3,
-    name: "에이블짐 잠실",
-    address: "서울 송파구 올림픽로35가길 12 5층 001호",
-  },
-  {
-    id: 4,
-    name: "에이블필라테스 잠실",
-    address: "서울 송파구 올림픽로35가길 13 10층 001호",
-  },
-];
+import { usePathname } from "next/navigation";
+import { useState } from "react";
+import * as MS from "./style";
 
 export default function FacilitySearch() {
   const [facilityValue, setFacilityValue] = useState("");
-  const [searchResults, setSearchResults] = useState<
-    {
-      id: number;
-      name: string;
-      address: string;
-    }[]
-  >([]);
+
+  const { data: searchResults } = usePlacesSearch(facilityValue);
+
   const [selectedPreferenceFacilities, setSelectedPreferenceFacilities] =
     useState<
       {
@@ -48,22 +26,6 @@ export default function FacilitySearch() {
       }[]
     >([]);
 
-  useEffect(() => {
-    if (facilityValue.trim() === "") {
-      setSearchResults([]);
-      return;
-    }
-
-    const timeout = setTimeout(() => {
-      const filteredResults = dummy2Facilities.filter((facility) =>
-        facility.name.includes(facilityValue),
-      );
-      setSearchResults(filteredResults);
-    }, 1000);
-
-    return () => clearTimeout(timeout);
-  }, [facilityValue]);
-
   const handleSelectFacility = (facility: {
     id: number;
     name: string;
@@ -71,10 +33,6 @@ export default function FacilitySearch() {
   }) => {
     if (selectedPreferenceFacilities.length < 3) {
       setSelectedPreferenceFacilities((prev) => [...prev, facility]);
-      localStorage.setItem(
-        "selectedPreferenceFacilities",
-        JSON.stringify([...selectedPreferenceFacilities, facility]),
-      );
     }
   };
 
@@ -83,10 +41,6 @@ export default function FacilitySearch() {
       (facility) => facility.id !== id,
     );
     setSelectedPreferenceFacilities(updatedFacilities);
-    localStorage.setItem(
-      "selectedPreferenceFacilities",
-      JSON.stringify(updatedFacilities),
-    );
   };
 
   const pathname = usePathname();
@@ -150,15 +104,12 @@ export default function FacilitySearch() {
 
         <S.ResultList>
           {searchResults.map((result) => (
-            <S.ResultItem
-              key={result.id}
-              onClick={() => handleSelectFacility(result)}
-            >
+            <S.ResultItem key={result.addressName}>
               <img src="/next.svg" width="40" height="40" />
               <S.FacilityInfo>
-                <Typography.H4Sb>{result.name}</Typography.H4Sb>
+                <Typography.H4Sb>{result.placeName}</Typography.H4Sb>
                 <Typography.H5Md color="#8A92A3">
-                  {result.address}
+                  {result.addressName}
                 </Typography.H5Md>
               </S.FacilityInfo>
             </S.ResultItem>

--- a/app/mypage/facility/FacilitySearch.tsx
+++ b/app/mypage/facility/FacilitySearch.tsx
@@ -13,9 +13,15 @@ import { setFacilityPreference } from "@/services/mypage/setFacilityPreferences"
 import { useMutation } from "@tanstack/react-query";
 import { usePathname, useRouter } from "next/navigation";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { WorkoutType } from "../sports/page";
 import * as MS from "./style";
+
+type FacilityRequestBody = {
+  preferredWorkoutTime: string | null;
+  favoriteWorkouts: { code: string; name: string }[] | null;
+  favoritePlaces: { placeName: string; address: string }[] | null;
+};
 
 export default function FacilitySearch() {
   const [facilityValue, setFacilityValue] = useState("");
@@ -59,7 +65,12 @@ export default function FacilitySearch() {
     setSelectedPreferenceFacilities(updatedFacilities);
   };
 
-  const { mutate: updateFacilityPreference } = useMutation({
+  const { mutate: updateFacilityPreference } = useMutation<
+    void,
+    unknown,
+    FacilityRequestBody,
+    any
+  >({
     mutationFn: () =>
       setFacilityPreference({
         preferredWorkoutTime: userInfo?.preferredWorkoutTime ?? null,
@@ -77,10 +88,9 @@ export default function FacilitySearch() {
         if (!oldData) return oldData;
         return {
           ...oldData,
-          preferredWorkoutTime: oldData.preferredWorkoutTime,
-          favoriteWorkouts:
-            oldData.favoriteWorkouts?.map((w: WorkoutType) => w.code) ?? null,
-          favoritePlaces: oldData.favoritePlaces ?? null,
+          preferredWorkoutTime: newData.preferredWorkoutTime,
+          favoriteWorkouts: newData.favoriteWorkouts,
+          favoritePlaces: newData.favoritePlaces,
         };
       });
 
@@ -103,12 +113,23 @@ export default function FacilitySearch() {
 
   const buttonClickHandler = () => {
     if (selectedPreferenceFacilities.length > 0) {
-      updateFacilityPreference();
+      const requestBody: FacilityRequestBody = {
+        preferredWorkoutTime: userInfo?.preferredWorkoutTime ?? null,
+        favoriteWorkouts: userInfo?.favoriteWorkouts ?? null,
+        favoritePlaces: selectedPreferenceFacilities,
+      };
+      updateFacilityPreference(requestBody);
     }
   };
 
   const pathname = usePathname();
   const isMypageFacility = pathname === "/mypage/facility";
+
+  useEffect(() => {
+    if (userInfo?.favoritePlaces) {
+      setSelectedPreferenceFacilities(userInfo.favoritePlaces);
+    }
+  }, [userInfo]);
 
   return (
     <>

--- a/app/mypage/facility/FacilitySearch.tsx
+++ b/app/mypage/facility/FacilitySearch.tsx
@@ -112,7 +112,7 @@ export default function FacilitySearch() {
 
   return (
     <>
-      <MS.facilityContainer2>
+      <MS.facilityNewContainer>
         <MS.facilityContent>
           <MS.facilityTitle>
             <Typography.H1Sb>선호하는</Typography.H1Sb>
@@ -198,7 +198,7 @@ export default function FacilitySearch() {
             변경완료
           </Button>
         </MS.ButtonContainer>
-      </MS.facilityContainer2>
+      </MS.facilityNewContainer>
     </>
   );
 }

--- a/app/mypage/facility/FacilitySearch.tsx
+++ b/app/mypage/facility/FacilitySearch.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import * as S from "@/app/mate/facility/style";
 import LogoumbbellsIcon from "@/assets/images/LogoDumbbells.svg";
 import XIcon from "@/assets/images/x.svg";
 import { Typography } from "@/components/atoms/Typography";
@@ -113,23 +112,23 @@ export default function FacilitySearch() {
 
   return (
     <>
-      <S.facilityContainer2>
-        <S.facilityContent>
-          <S.facilityTitle>
+      <MS.facilityContainer2>
+        <MS.facilityContent>
+          <MS.facilityTitle>
             <Typography.H1Sb>선호하는</Typography.H1Sb>
             <Typography.H1Sb color="#004DFF">
               <br />
               운동 시설
             </Typography.H1Sb>
             <Typography.H1Sb>을 선택해주세요!</Typography.H1Sb>
-          </S.facilityTitle>
+          </MS.facilityTitle>
           <Typography.H4Md color="#8A92A3">
             최소 1개, 최대 3개까지 선택해주세요.
           </Typography.H4Md>
-        </S.facilityContent>
+        </MS.facilityContent>
 
         {selectedPreferenceFacilities.length > 0 && (
-          <S.AddText>나의 선호 시설</S.AddText>
+          <MS.AddText>나의 선호 시설</MS.AddText>
         )}
         <MS.PreferencePlaceWrapper>
           {selectedPreferenceFacilities.map((facility) => (
@@ -157,7 +156,7 @@ export default function FacilitySearch() {
           ))}
         </MS.PreferencePlaceWrapper>
 
-        <S.PlaceHolderWrapper>
+        <MS.PlaceHolderWrapper>
           <Placeholder
             text={
               isMypageFacility ? "ex. 아워핏짐 잠실" : "시설 명을 검색해주세요"
@@ -165,11 +164,11 @@ export default function FacilitySearch() {
             onChange={(e) => setFacilityValue(e.target.value)}
             inputValue={facilityValue}
           />
-        </S.PlaceHolderWrapper>
+        </MS.PlaceHolderWrapper>
 
-        <S.ResultList>
+        <MS.ResultList>
           {searchResults.map((result) => (
-            <S.ResultItem
+            <MS.ResultItem
               key={result.addressName}
               onClick={() =>
                 handleSelectFacility({
@@ -179,15 +178,15 @@ export default function FacilitySearch() {
               }
             >
               <img src="/next.svg" width="40" height="40" />
-              <S.FacilityInfo>
+              <MS.FacilityInfo>
                 <Typography.H4Sb>{result.placeName}</Typography.H4Sb>
                 <Typography.H5Md color="#8A92A3">
                   {result.addressName}
                 </Typography.H5Md>
-              </S.FacilityInfo>
-            </S.ResultItem>
+              </MS.FacilityInfo>
+            </MS.ResultItem>
           ))}
-        </S.ResultList>
+        </MS.ResultList>
 
         <MS.ButtonContainer>
           <Button
@@ -199,7 +198,7 @@ export default function FacilitySearch() {
             변경완료
           </Button>
         </MS.ButtonContainer>
-      </S.facilityContainer2>
+      </MS.facilityContainer2>
     </>
   );
 }

--- a/app/mypage/facility/FacilitySearch.tsx
+++ b/app/mypage/facility/FacilitySearch.tsx
@@ -2,45 +2,110 @@
 
 import * as S from "@/app/mate/facility/style";
 import LogoumbbellsIcon from "@/assets/images/LogoDumbbells.svg";
+import XIcon from "@/assets/images/x.svg";
 import { Typography } from "@/components/atoms/Typography";
 import Button from "@/components/common/Button";
 import Placeholder from "@/components/common/Placeholder/Placeholder";
+import { queryClient } from "@/components/common/ReactQueryProvider";
+import { BUTTON_SIZES, BUTTON_VARIANTS } from "@/constants/Button";
+import { useMyPageInfo } from "@/hooks/queries/useMypageInfo";
 import { usePlacesSearch } from "@/hooks/queries/usePlacesSearch";
-import { Container } from "@mui/material";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { setFacilityPreference } from "@/services/mypage/setFacilityPreferences";
+import { useMutation } from "@tanstack/react-query";
+import { usePathname, useRouter } from "next/navigation";
+
 import { useState } from "react";
+import { WorkoutType } from "../sports/page";
 import * as MS from "./style";
 
 export default function FacilitySearch() {
   const [facilityValue, setFacilityValue] = useState("");
+  const router = useRouter();
 
   const { data: searchResults } = usePlacesSearch(facilityValue);
+  const { data: userInfo } = useMyPageInfo();
 
   const [selectedPreferenceFacilities, setSelectedPreferenceFacilities] =
     useState<
       {
-        id: number;
-        name: string;
+        placeName: string;
         address: string;
       }[]
     >([]);
 
   const handleSelectFacility = (facility: {
-    id: number;
-    name: string;
+    placeName: string;
     address: string;
   }) => {
+    const alreadySelected = selectedPreferenceFacilities.some(
+      (f) =>
+        f.placeName === facility.placeName && f.address === facility.address,
+    );
+
+    if (alreadySelected) {
+      return;
+    }
+
     if (selectedPreferenceFacilities.length < 3) {
       setSelectedPreferenceFacilities((prev) => [...prev, facility]);
+    } else {
+      return;
     }
   };
 
-  const handleRemoveFacility = (id: number) => {
+  const handleRemoveFacility = (placeName: string) => {
     const updatedFacilities = selectedPreferenceFacilities.filter(
-      (facility) => facility.id !== id,
+      (facility) => facility.placeName !== placeName,
     );
     setSelectedPreferenceFacilities(updatedFacilities);
+  };
+
+  const { mutate: updateFacilityPreference } = useMutation({
+    mutationFn: () =>
+      setFacilityPreference({
+        preferredWorkoutTime: userInfo?.preferredWorkoutTime ?? null,
+        favoriteWorkouts:
+          userInfo?.favoriteWorkouts?.map((w: WorkoutType) => w.code) ?? null,
+        favoritePlaces: selectedPreferenceFacilities,
+      }),
+
+    onMutate: async (newData) => {
+      await queryClient.cancelQueries({ queryKey: ["myPageInfo"] });
+
+      const previousData = queryClient.getQueryData(["myPageInfo"]);
+
+      queryClient.setQueryData(["myPageInfo"], (oldData: any) => {
+        if (!oldData) return oldData;
+        return {
+          ...oldData,
+          preferredWorkoutTime: oldData.preferredWorkoutTime,
+          favoriteWorkouts:
+            oldData.favoriteWorkouts?.map((w: WorkoutType) => w.code) ?? null,
+          favoritePlaces: oldData.favoritePlaces ?? null,
+        };
+      });
+
+      return { previousData };
+    },
+
+    onError: (error, _, context) => {
+      if (context?.previousData) {
+        queryClient.setQueryData(["myPageInfo"], context.previousData);
+      }
+      alert("운동 시설 정보를 수정하는데 실패했습니다.");
+      console.error(error);
+    },
+
+    onSuccess: async () => {
+      await queryClient.refetchQueries({ queryKey: ["myPageInfo"] });
+      router.back();
+    },
+  });
+
+  const buttonClickHandler = () => {
+    if (selectedPreferenceFacilities.length > 0) {
+      updateFacilityPreference();
+    }
   };
 
   const pathname = usePathname();
@@ -68,7 +133,7 @@ export default function FacilitySearch() {
         )}
         <MS.PreferencePlaceWrapper>
           {selectedPreferenceFacilities.map((facility) => (
-            <MS.PreferencePlaceContainer key={facility.id}>
+            <MS.PreferencePlaceContainer key={facility.placeName}>
               <MS.PreferencePlaceInfo2>
                 <MS.PreferenceInfoWrapper>
                   <LogoumbbellsIcon
@@ -77,15 +142,15 @@ export default function FacilitySearch() {
                     height={20}
                   />
 
-                  <MS.PreferencePlaceName2>
-                    {facility.name}
-                  </MS.PreferencePlaceName2>
+                  <Typography.H5Sb color="#004DFF">
+                    {facility.placeName}
+                  </Typography.H5Sb>
                 </MS.PreferenceInfoWrapper>
 
                 <MS.PreferenceButton
-                  onClick={() => handleRemoveFacility(facility.id)}
+                  onClick={() => handleRemoveFacility(facility.placeName)}
                 >
-                  X
+                  <XIcon color="#8AADFF" />
                 </MS.PreferenceButton>
               </MS.PreferencePlaceInfo2>
             </MS.PreferencePlaceContainer>
@@ -104,7 +169,15 @@ export default function FacilitySearch() {
 
         <S.ResultList>
           {searchResults.map((result) => (
-            <S.ResultItem key={result.addressName}>
+            <S.ResultItem
+              key={result.addressName}
+              onClick={() =>
+                handleSelectFacility({
+                  placeName: result.placeName,
+                  address: result.addressName,
+                })
+              }
+            >
               <img src="/next.svg" width="40" height="40" />
               <S.FacilityInfo>
                 <Typography.H4Sb>{result.placeName}</Typography.H4Sb>
@@ -116,13 +189,16 @@ export default function FacilitySearch() {
           ))}
         </S.ResultList>
 
-        <Container>
-          <Link href="/mypage" passHref>
-            <Button size="l" variant="primary" disabled={false}>
-              변경 완료
-            </Button>
-          </Link>
-        </Container>
+        <MS.ButtonContainer>
+          <Button
+            disabled={selectedPreferenceFacilities.length === 0}
+            size={BUTTON_SIZES.LARGE}
+            variant={BUTTON_VARIANTS.PRIMARY}
+            onClick={buttonClickHandler}
+          >
+            변경완료
+          </Button>
+        </MS.ButtonContainer>
       </S.facilityContainer2>
     </>
   );

--- a/app/mypage/facility/style.ts
+++ b/app/mypage/facility/style.ts
@@ -75,6 +75,21 @@ export const PreferencePlaceContainer = styled.div`
   align-items: center;
 `;
 
+export const PreferencePlaceItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+
+  padding: 16px 20px;
+  box-sizing: border-box;
+
+  width: 100%;
+  height: 75px;
+  border: 1px solid ${COLORS.GRAYSCALE_200};
+  border-radius: 16px;
+`;
+
 export const PreferencePlaceInfo = styled.div`
   display: flex;
   flex-direction: column;
@@ -117,6 +132,8 @@ export const PreferencePlaceInfo2 = styled.div`
   display: flex;
   flex-wrap: wrap;
   padding: 8px 10px;
+
+  width: 100%;
   align-items: center;
   gap: 4px;
 
@@ -137,4 +154,17 @@ export const PreferenceButton = styled.button`
   border: none;
   color: #8aadff;
   background: ${COLORS.BLUE_50};
+
+  cursor: pointer;
+`;
+
+export const ButtonContainer = styled.div`
+  display: flex;
+  width: 100%;
+  max-width: 410px;
+  justify-content: center;
+  align-items: center;
+  margin-top: auto;
+
+  padding: 12px 0px 20px 0px;
 `;

--- a/app/mypage/facility/style.ts
+++ b/app/mypage/facility/style.ts
@@ -162,12 +162,13 @@ export const PreferenceButton = styled.button`
 export const ButtonContainer = styled.div`
   display: flex;
   width: 100%;
-  max-width: 410px;
+  max-width: 450px;
   justify-content: center;
   align-items: center;
   margin-top: auto;
 
-  padding: 12px 0px 20px 0px;
+  padding: 12px 20px 20px 20px;
+  box-sizing: border-box;
 `;
 
 export const facilityContainer = styled.div`
@@ -181,15 +182,24 @@ export const facilityContainer = styled.div`
   gap: 36px;
 `;
 
-export const facilityContainer2 = styled.div`
+export const facilityNewContainer = styled.div`
   display: flex;
   flex-direction: column;
 
   justify-content: flex-start;
   align-items: center;
-  flex-grow: 1;
+  flex: 1;
+
+  overflow-y: auto;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  scrollbar-width: none;
 
   height: 100%;
+
   gap: 36px;
 `;
 
@@ -236,8 +246,9 @@ export const ResultList = styled.div`
   gap: 16px;
 
   width: 100%;
-  max-width: 410px;
+  max-width: 450px;
   padding: 0px 20px;
+  box-sizing: border-box;
 
   overflow-y: auto;
 
@@ -252,11 +263,14 @@ export const ResultList = styled.div`
     background-color: transparent;
   }
 
-  height: 100%;
+  height: auto;
+  min-height: 200px;
+  flex: 1;
 `;
 
 export const ResultItem = styled.div`
   display: flex;
+  justify-content: flex-start;
   gap: 12px;
 
   width: 100%;
@@ -268,6 +282,7 @@ export const FacilityInfo = styled.div`
   flex-direction: column;
 
   align-items: flex-start;
+  gap: 2px;
 
   width: 298px;
   height: 100%;

--- a/app/mypage/facility/style.ts
+++ b/app/mypage/facility/style.ts
@@ -4,6 +4,7 @@ import styled from "styled-components";
 export const PreferenceFacilityWrapper = styled.div`
   display: flex;
   flex-direction: column;
+
   gap: 12px;
   padding: 28px 20px;
   box-sizing: border-box;
@@ -167,4 +168,125 @@ export const ButtonContainer = styled.div`
   margin-top: auto;
 
   padding: 12px 0px 20px 0px;
+`;
+
+export const facilityContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+
+  width: 100%;
+  height: 100%;
+
+  gap: 36px;
+`;
+
+export const facilityContainer2 = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  justify-content: flex-start;
+  align-items: center;
+  flex-grow: 1;
+
+  height: 100%;
+  gap: 36px;
+`;
+
+export const facilityContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  width: 100%;
+  max-width: 450px;
+  height: auto;
+
+  padding: 48px 20px 0px 20px;
+  box-sizing: border-box;
+`;
+
+export const facilityTitle = styled.div`
+  width: 350px;
+  height: 64px;
+
+  white-space: pre-line;
+  word-break: break-word;
+`;
+
+export const HighlightedText = styled.span`
+  color: #004dff;
+`;
+
+export const PlaceHolderWrapper = styled.div`
+  display: flex;
+
+  width: 100%;
+  padding: 0px 20px;
+  box-sizing: border-box;
+
+  height: auto;
+`;
+
+export const ResultList = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+
+  gap: 16px;
+
+  width: 100%;
+  max-width: 410px;
+  padding: 0px 20px;
+
+  overflow-y: auto;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: #c4c4c4;
+    border-radius: 3px;
+  }
+  &::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+
+  height: 100%;
+`;
+
+export const ResultItem = styled.div`
+  display: flex;
+  gap: 12px;
+
+  width: 100%;
+  height: 43px;
+`;
+
+export const FacilityInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  align-items: flex-start;
+
+  width: 298px;
+  height: 100%;
+`;
+
+export const AddText = styled.div`
+  display: flex;
+  padding: 0px 20px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  align-self: stretch;
+
+  color: var(--Blue-500, #004eff);
+
+  font-family: Pretendard;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 150%;
+  letter-spacing: -0.14px;
 `;

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -1,8 +1,12 @@
 "use client";
 
+import Toast from "@/components/common/Toast/Toast";
+import { TOAST_STATUSES } from "@/constants/Toast";
 import { useMyPageInfo } from "@/hooks/queries/useMypageInfo";
 import { setImageUrl } from "@/services/mypage/setImageUrl";
+import { ToastProps } from "@/types/toast";
 import { readFileAsDataURL } from "@/utils/readFileAsDataURL";
+import { AxiosError } from "axios";
 import { useEffect, useRef, useState } from "react";
 import EditBasicInfo from "./_components/EditBasicInfo";
 import EditProfile from "./_components/EditProfile";
@@ -26,6 +30,7 @@ const managementLinks = [
 ];
 
 export default function Mypage() {
+  const [toast, setToast] = useState<ToastProps | null>(null);
   const { data: userInfo, refetch } = useMyPageInfo();
 
   const [isEditingProfile, setIsEditingProfile] = useState(false);
@@ -73,8 +78,16 @@ export default function Mypage() {
         await setImageUrl(file);
 
         await refetch();
-      } catch (error) {
-        console.error("Error reading file:", error);
+      } catch (error: unknown) {
+        if (error instanceof AxiosError && error.response?.status === 429) {
+          setToast({
+            message: "1분 뒤에 프로필 변경이 가능해요! ",
+            status: TOAST_STATUSES.ERROR,
+          });
+          setTimeout(() => {
+            setToast(null);
+          }, 3000);
+        }
       }
     }
   };
@@ -85,44 +98,43 @@ export default function Mypage() {
     }
   }, [userInfo?.introduction]);
 
-  if (isEditingProfile) {
-    return (
-      <EditProfile
-        handleEditProfile={handleEditProfile}
-        isEditingDescription={isEditingDescription}
-        profileImage={userInfo?.profileUrl}
-        nickname={userInfo?.nickname}
-        gender={userInfo?.gender}
-        age={userInfo?.age}
-        skillLevel={userInfo?.skillLevel}
-        handleProfileImageClick={() => fileInputRef.current?.click()}
-        handleEditDescription={handleEditDescription}
-        fileInputRef={fileInputRef}
-        handleFileChange={handleFileChange}
-        introduction={introduction}
-        handleIntroductionChange={handleIntroductionChange}
-        handleIntroductionBlur={handleIntroductionBlur}
-        descriptionInputRef={descriptionInputRef}
-      />
-    );
-  }
-
-  if (isEditingBasicInfo) {
-    return <EditBasicInfo handleEditBasicInfo={handleEditBasicInfo} />;
-  }
-
   return (
-    <ViewProfile
-      profileImage={userInfo?.profileUrl}
-      nickname={userInfo?.nickname}
-      gender={userInfo?.gender}
-      sns={userInfo?.oAuthProvider}
-      age={userInfo?.age}
-      email={userInfo?.email}
-      skillLevel={userInfo?.skillLevel}
-      handleEditProfile={handleEditProfile}
-      handleEditBasicInfo={handleEditBasicInfo}
-      managementLinks={managementLinks}
-    />
+    <>
+      {isEditingProfile ? (
+        <EditProfile
+          handleEditProfile={handleEditProfile}
+          isEditingDescription={isEditingDescription}
+          profileImage={userInfo?.profileUrl}
+          nickname={userInfo?.nickname}
+          gender={userInfo?.gender}
+          age={userInfo?.age}
+          skillLevel={userInfo?.skillLevel}
+          handleProfileImageClick={() => fileInputRef.current?.click()}
+          handleEditDescription={handleEditDescription}
+          fileInputRef={fileInputRef}
+          handleFileChange={handleFileChange}
+          introduction={introduction}
+          handleIntroductionChange={handleIntroductionChange}
+          handleIntroductionBlur={handleIntroductionBlur}
+          descriptionInputRef={descriptionInputRef}
+        />
+      ) : isEditingBasicInfo ? (
+        <EditBasicInfo handleEditBasicInfo={handleEditBasicInfo} />
+      ) : (
+        <ViewProfile
+          profileImage={userInfo?.profileUrl}
+          nickname={userInfo?.nickname}
+          gender={userInfo?.gender}
+          sns={userInfo?.oAuthProvider}
+          age={userInfo?.age}
+          email={userInfo?.email}
+          skillLevel={userInfo?.skillLevel}
+          handleEditProfile={handleEditProfile}
+          handleEditBasicInfo={handleEditBasicInfo}
+          managementLinks={managementLinks}
+        />
+      )}
+      {toast && <Toast message={toast.message} status={toast.status} />}
+    </>
   );
 }

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { useMyPageInfo } from "@/hooks/queries/useMypageInfo";
 import { setImageUrl } from "@/services/mypage/setImageUrl";
-import { useUserInfoStore } from "@/stores/userInfoStore";
 import { readFileAsDataURL } from "@/utils/readFileAsDataURL";
 import { useEffect, useRef, useState } from "react";
 import EditBasicInfo from "./_components/EditBasicInfo";
@@ -26,7 +26,7 @@ const managementLinks = [
 ];
 
 export default function Mypage() {
-  const { userInfo, fetchUserInfo } = useUserInfoStore();
+  const { data: userInfo, refetch } = useMyPageInfo();
 
   const [isEditingProfile, setIsEditingProfile] = useState(false);
   const [isEditingBasicInfo, setIsEditingBasicInfo] = useState(false);
@@ -72,16 +72,12 @@ export default function Mypage() {
 
         await setImageUrl(file);
 
-        await fetchUserInfo();
+        await refetch();
       } catch (error) {
         console.error("Error reading file:", error);
       }
     }
   };
-
-  useEffect(() => {
-    fetchUserInfo();
-  }, []);
 
   useEffect(() => {
     if (userInfo?.introduction !== undefined) {

--- a/app/mypage/sports/Sports.tsx
+++ b/app/mypage/sports/Sports.tsx
@@ -1,12 +1,16 @@
+import Dumbbels from "@/assets/images/dumbbells.svg";
 import { Typography } from "@/components/atoms/Typography";
+import { useMyPageInfo } from "@/hooks/queries/useMypageInfo";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
 import * as S from "./style";
 
-export default function Sports() {
-  const pathname = usePathname();
-  const isMypageSports = pathname === "/mypage/sports";
+interface WorkoutProps {
+  code: string;
+  name: string;
+}
 
+export default function Sports() {
+  const { data: userInfo } = useMyPageInfo();
   return (
     <S.PreferenceSectionWrapper>
       <S.PreferenceHeader>
@@ -21,7 +25,14 @@ export default function Sports() {
         </Link>
       </S.PreferenceHeader>
 
-      <S.PreferenceContent></S.PreferenceContent>
+      <S.PreferenceContent>
+        {userInfo?.favoriteWorkouts?.map((workout: WorkoutProps) => (
+          <S.PreferenceBadge key={workout.code}>
+            <Dumbbels color={"#004DFF"} />
+            {workout.name}
+          </S.PreferenceBadge>
+        ))}
+      </S.PreferenceContent>
     </S.PreferenceSectionWrapper>
   );
 }

--- a/app/mypage/sports/Sports.tsx
+++ b/app/mypage/sports/Sports.tsx
@@ -29,7 +29,7 @@ export default function Sports() {
         {userInfo?.favoriteWorkouts?.map((workout: WorkoutProps) => (
           <S.PreferenceBadge key={workout.code}>
             <Dumbbels color={"#004DFF"} />
-            {workout.name}
+            <Typography.H4Md>{workout.name}</Typography.H4Md>
           </S.PreferenceBadge>
         ))}
       </S.PreferenceContent>

--- a/app/mypage/sports/Sports.tsx
+++ b/app/mypage/sports/Sports.tsx
@@ -1,14 +1,9 @@
-import Dumbbells from "@/assets/images/dumbbells.svg";
 import { Typography } from "@/components/atoms/Typography";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import * as S from "./style";
 
-interface SportsProps {
-  preferences: string[];
-}
-
-export default function Sports({ preferences }: SportsProps) {
+export default function Sports() {
   const pathname = usePathname();
   const isMypageSports = pathname === "/mypage/sports";
 
@@ -17,23 +12,16 @@ export default function Sports({ preferences }: SportsProps) {
       <S.PreferenceHeader>
         <S.PreferenceTitle>
           선호 운동
-          <Typography.H3Bd style={{ marginLeft: "4px", color: "#004DFF" }}>
-            {preferences.length}
-          </Typography.H3Bd>
+          <Typography.H3Bd
+            style={{ marginLeft: "4px", color: "#004DFF" }}
+          ></Typography.H3Bd>
         </S.PreferenceTitle>
         <Link href="/mypage/sports">
           <S.PreferenceEdit>편집</S.PreferenceEdit>
         </Link>
       </S.PreferenceHeader>
 
-      <S.PreferenceContent>
-        {preferences.map((sport) => (
-          <S.PreferenceBadge key={sport}>
-            <Dumbbells color={"#004DFF"} />
-            <span>{sport}</span>
-          </S.PreferenceBadge>
-        ))}
-      </S.PreferenceContent>
+      <S.PreferenceContent></S.PreferenceContent>
     </S.PreferenceSectionWrapper>
   );
 }

--- a/app/mypage/sports/page.tsx
+++ b/app/mypage/sports/page.tsx
@@ -12,7 +12,7 @@ import { useWorkoutTypes } from "@/hooks/queries/useWorkoutTypes";
 import { setWorkoutPreferences } from "@/services/mypage/setWorkoutPreferences";
 import { useMutation } from "@tanstack/react-query";
 import { usePathname, useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import * as S from "./style";
 
 export interface WorkoutType {
@@ -98,6 +98,14 @@ const SportsPreference = () => {
 
     updateWorkoutPreferences(requestBody);
   };
+
+  useEffect(() => {
+    if (userInfo?.favoriteWorkouts) {
+      setSelectedSports(
+        userInfo.favoriteWorkouts.map((v: WorkoutType) => v.code),
+      );
+    }
+  }, [userInfo]);
 
   return (
     <>

--- a/app/mypage/sports/page.tsx
+++ b/app/mypage/sports/page.tsx
@@ -1,18 +1,91 @@
 "use client";
 
+import { Typography } from "@/components/atoms/Typography";
+import Button from "@/components/common/Button";
 import Header from "@/components/common/Header/Header";
-import { SIGNUP_STEPS } from "@/constants/Signup";
-import { Container } from "@mui/material";
-import React, { useState } from "react";
-import SignupForm from "@/components/auth/signup/SignupForm";
+import TextButton from "@/components/common/TextButton";
+import { BUTTON_SIZES, BUTTON_VARIANTS } from "@/constants/Button";
+import { SPORTS_LABEL, STEPS_LABEL } from "@/constants/Signup";
+import { COLORS } from "@/constants/Theme";
+import { StepProps } from "@/types/step";
+import { usePathname, useRouter } from "next/navigation";
+import { useState } from "react";
+import * as S from "./style";
 
-export default function Page() {
-  const [step, setStep] = useState<number>(SIGNUP_STEPS[5].id);
+const SportsPreference = ({ nextStep }: StepProps) => {
+  const [selectedSports, setSelectedSports] = useState<string[]>([]);
+  const router = useRouter();
+  const pathname = usePathname();
+  const isMypageSports = pathname === "/mypage/sports";
+  const isSignup = pathname === "/auth/signup";
+
+  const handleSportClick = (sport: string) => {
+    setSelectedSports((prev) => {
+      if (prev.includes(sport)) {
+        return prev.filter((item) => item !== sport);
+      } else if (prev.length < 3) {
+        return [...prev, sport];
+      } else {
+        return prev;
+      }
+    });
+  };
+
+  const buttonClickHandler = () => {
+    if (selectedSports.length >= 1 && nextStep) {
+      nextStep(STEPS_LABEL.SPORTS_PREFERENCES, selectedSports);
+    }
+
+    if (isMypageSports) {
+      router.back();
+    }
+  };
 
   return (
     <>
       <Header />
-      <SignupForm step={step} setStep={setStep} />
+      <S.SportsPreferenceWrapper $isHeightFull={!isSignup}>
+        <S.SignupIntroContainer>
+          <S.SignupIntroTitleWrapper>
+            <Typography.H1Sb>
+              선호하는 <span style={{ color: COLORS.BLUE_500 }}>운동</span>을
+              선택해주세요!
+            </Typography.H1Sb>
+          </S.SignupIntroTitleWrapper>
+          <Typography.H4Md color={COLORS.GRAYSCALE_600}>
+            최소 1개, 최대 3개까지 선택해주세요.
+          </Typography.H4Md>
+        </S.SignupIntroContainer>
+        <S.InfoContainer>
+          <S.TextButtonWrapper>
+            {Object.values(SPORTS_LABEL).map((sport) => (
+              <TextButton
+                key={sport}
+                isActive={selectedSports.includes(sport)}
+                onClick={() => handleSportClick(sport)}
+              >
+                {sport}
+              </TextButton>
+            ))}
+          </S.TextButtonWrapper>
+        </S.InfoContainer>
+      </S.SportsPreferenceWrapper>
+      <S.ButtonContainer>
+        <Button
+          disabled={selectedSports.length === 0}
+          size={BUTTON_SIZES.LARGE}
+          variant={BUTTON_VARIANTS.PRIMARY}
+          onClick={buttonClickHandler}
+          style={{
+            maxWidth: "410px",
+            height: "53px",
+          }}
+        >
+          {isMypageSports ? "변경 완료" : "다음"}
+        </Button>
+      </S.ButtonContainer>
     </>
   );
-}
+};
+
+export default SportsPreference;

--- a/app/mypage/sports/page.tsx
+++ b/app/mypage/sports/page.tsx
@@ -15,7 +15,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
 import * as S from "./style";
 
-interface WorkoutType {
+export interface WorkoutType {
   code: string;
   name: string;
 }
@@ -27,7 +27,7 @@ const SportsPreference = ({ nextStep }: StepProps) => {
   const isMypageSports = pathname === "/mypage/sports";
   const isSignup = pathname === "/auth/signup";
 
-  const { data: userInfo, refetch } = useMyPageInfo();
+  const { data: userInfo } = useMyPageInfo();
   const { data: workoutTypes } = useWorkoutTypes();
 
   const handleSportClick = (sport: string) => {

--- a/app/mypage/sports/page.tsx
+++ b/app/mypage/sports/page.tsx
@@ -11,6 +11,7 @@ import { useMyPageInfo } from "@/hooks/queries/useMypageInfo";
 import { useWorkoutTypes } from "@/hooks/queries/useWorkoutTypes";
 import { setWorkoutPreferences } from "@/services/mypage/setWorkoutPreferences";
 import { StepProps } from "@/types/step";
+import { useMutation } from "@tanstack/react-query";
 import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
 import * as S from "./style";
@@ -42,31 +43,61 @@ const SportsPreference = ({ nextStep }: StepProps) => {
     });
   };
 
-  const buttonClickHandler = async () => {
-    if (isMypageSports) {
-      try {
-        const preferredWorkoutTime = userInfo?.preferredWorkoutTime ?? null;
-        const favoritePlaces = userInfo?.favoritePlaces ?? null;
+  const { mutate: updateWorkoutPreferences } = useMutation({
+    mutationFn: async (requestBody: {
+      preferredWorkoutTime: string | null;
+      favoriteWorkouts: string[];
+      favoritePlaces:
+        | {
+            placeName: string;
+            address: string;
+          }[]
+        | null;
+    }) => {
+      return await setWorkoutPreferences(requestBody);
+    },
 
-        const requestBody = {
-          preferredWorkoutTime,
-          favoriteWorkouts: selectedSports,
-          favoritePlaces,
+    onMutate: async (newData) => {
+      await queryClient.cancelQueries({ queryKey: ["myPageInfo"] });
+
+      const previousData = queryClient.getQueryData(["myPageInfo"]);
+
+      queryClient.setQueryData(["myPageInfo"], (oldData: any) => {
+        if (!oldData) return oldData;
+        return {
+          ...oldData,
+          preferredWorkoutTime: newData.preferredWorkoutTime,
+          favoriteWorkouts: newData.favoriteWorkouts,
+          favoritePlaces: newData.favoritePlaces,
         };
+      });
 
-        await setWorkoutPreferences(requestBody);
+      return { previousData };
+    },
 
-        await queryClient.refetchQueries({
-          queryKey: ["myPageInfo"],
-          type: "active",
-        });
-
-        router.back();
-      } catch (error) {
-        console.error(error);
-        alert("운동 선호 정보를 수정하는데 실패했습니다.");
+    onError: (error, _newData, context) => {
+      if (context?.previousData) {
+        queryClient.setQueryData(["myPageInfo"], context.previousData);
       }
-    }
+      alert("운동 선호 정보를 수정하는데 실패했습니다.");
+      console.error(error);
+    },
+
+    onSuccess: async () => {
+      await queryClient.refetchQueries({ queryKey: ["myPageInfo"] });
+
+      router.back();
+    },
+  });
+
+  const buttonClickHandler = () => {
+    const requestBody = {
+      preferredWorkoutTime: userInfo?.preferredWorkoutTime ?? null,
+      favoriteWorkouts: selectedSports,
+      favoritePlaces: userInfo?.favoritePlaces ?? null,
+    };
+
+    updateWorkoutPreferences(requestBody);
   };
 
   return (

--- a/app/mypage/sports/page.tsx
+++ b/app/mypage/sports/page.tsx
@@ -3,6 +3,7 @@
 import { Typography } from "@/components/atoms/Typography";
 import Button from "@/components/common/Button";
 import Header from "@/components/common/Header/Header";
+import { queryClient } from "@/components/common/ReactQueryProvider";
 import TextButton from "@/components/common/TextButton";
 import { BUTTON_SIZES, BUTTON_VARIANTS } from "@/constants/Button";
 import { COLORS } from "@/constants/Theme";
@@ -55,7 +56,10 @@ const SportsPreference = ({ nextStep }: StepProps) => {
 
         await setWorkoutPreferences(requestBody);
 
-        await refetch();
+        await queryClient.refetchQueries({
+          queryKey: ["myPageInfo"],
+          type: "active",
+        });
 
         router.back();
       } catch (error) {
@@ -88,7 +92,7 @@ const SportsPreference = ({ nextStep }: StepProps) => {
                 isActive={selectedSports.includes(workout.code)}
                 onClick={() => handleSportClick(workout.code)}
               >
-                {workout.name}
+                <Typography.H4Md>{workout.name}</Typography.H4Md>
               </TextButton>
             ))}
           </S.TextButtonWrapper>

--- a/app/mypage/sports/page.tsx
+++ b/app/mypage/sports/page.tsx
@@ -127,21 +127,17 @@ const SportsPreference = () => {
             ))}
           </S.TextButtonWrapper>
         </S.InfoContainer>
+        <S.ButtonContainer>
+          <Button
+            disabled={selectedSports.length === 0}
+            size={BUTTON_SIZES.LARGE}
+            variant={BUTTON_VARIANTS.PRIMARY}
+            onClick={buttonClickHandler}
+          >
+            변경완료
+          </Button>
+        </S.ButtonContainer>
       </S.SportsPreferenceWrapper>
-      <S.ButtonContainer>
-        <Button
-          disabled={selectedSports.length === 0}
-          size={BUTTON_SIZES.LARGE}
-          variant={BUTTON_VARIANTS.PRIMARY}
-          onClick={buttonClickHandler}
-          style={{
-            maxWidth: "410px",
-            height: "53px",
-          }}
-        >
-          {isMypageSports ? "변경 완료" : "다음"}
-        </Button>
-      </S.ButtonContainer>
     </>
   );
 };

--- a/app/mypage/sports/page.tsx
+++ b/app/mypage/sports/page.tsx
@@ -10,7 +10,6 @@ import { COLORS } from "@/constants/Theme";
 import { useMyPageInfo } from "@/hooks/queries/useMypageInfo";
 import { useWorkoutTypes } from "@/hooks/queries/useWorkoutTypes";
 import { setWorkoutPreferences } from "@/services/mypage/setWorkoutPreferences";
-import { StepProps } from "@/types/step";
 import { useMutation } from "@tanstack/react-query";
 import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
@@ -21,7 +20,7 @@ export interface WorkoutType {
   name: string;
 }
 
-const SportsPreference = ({ nextStep }: StepProps) => {
+const SportsPreference = () => {
   const [selectedSports, setSelectedSports] = useState<string[]>([]);
   const router = useRouter();
   const pathname = usePathname();

--- a/app/mypage/sports/page.tsx
+++ b/app/mypage/sports/page.tsx
@@ -5,12 +5,19 @@ import Button from "@/components/common/Button";
 import Header from "@/components/common/Header/Header";
 import TextButton from "@/components/common/TextButton";
 import { BUTTON_SIZES, BUTTON_VARIANTS } from "@/constants/Button";
-import { SPORTS_LABEL, STEPS_LABEL } from "@/constants/Signup";
 import { COLORS } from "@/constants/Theme";
+import { useMyPageInfo } from "@/hooks/queries/useMypageInfo";
+import { useWorkoutTypes } from "@/hooks/queries/useWorkoutTypes";
+import { setWorkoutPreferences } from "@/services/mypage/setWorkoutPreferences";
 import { StepProps } from "@/types/step";
 import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
 import * as S from "./style";
+
+interface WorkoutType {
+  code: string;
+  name: string;
+}
 
 const SportsPreference = ({ nextStep }: StepProps) => {
   const [selectedSports, setSelectedSports] = useState<string[]>([]);
@@ -18,6 +25,9 @@ const SportsPreference = ({ nextStep }: StepProps) => {
   const pathname = usePathname();
   const isMypageSports = pathname === "/mypage/sports";
   const isSignup = pathname === "/auth/signup";
+
+  const { data: userInfo, refetch } = useMyPageInfo();
+  const { data: workoutTypes } = useWorkoutTypes();
 
   const handleSportClick = (sport: string) => {
     setSelectedSports((prev) => {
@@ -31,13 +41,27 @@ const SportsPreference = ({ nextStep }: StepProps) => {
     });
   };
 
-  const buttonClickHandler = () => {
-    if (selectedSports.length >= 1 && nextStep) {
-      nextStep(STEPS_LABEL.SPORTS_PREFERENCES, selectedSports);
-    }
-
+  const buttonClickHandler = async () => {
     if (isMypageSports) {
-      router.back();
+      try {
+        const preferredWorkoutTime = userInfo?.preferredWorkoutTime ?? null;
+        const favoritePlaces = userInfo?.favoritePlaces ?? null;
+
+        const requestBody = {
+          preferredWorkoutTime,
+          favoriteWorkouts: selectedSports,
+          favoritePlaces,
+        };
+
+        await setWorkoutPreferences(requestBody);
+
+        await refetch();
+
+        router.back();
+      } catch (error) {
+        console.error(error);
+        alert("운동 선호 정보를 수정하는데 실패했습니다.");
+      }
     }
   };
 
@@ -58,13 +82,13 @@ const SportsPreference = ({ nextStep }: StepProps) => {
         </S.SignupIntroContainer>
         <S.InfoContainer>
           <S.TextButtonWrapper>
-            {Object.values(SPORTS_LABEL).map((sport) => (
+            {workoutTypes?.map((workout: WorkoutType) => (
               <TextButton
-                key={sport}
-                isActive={selectedSports.includes(sport)}
-                onClick={() => handleSportClick(sport)}
+                key={workout.code}
+                isActive={selectedSports.includes(workout.code)}
+                onClick={() => handleSportClick(workout.code)}
               >
-                {sport}
+                {workout.name}
               </TextButton>
             ))}
           </S.TextButtonWrapper>

--- a/app/mypage/sports/style.ts
+++ b/app/mypage/sports/style.ts
@@ -113,3 +113,17 @@ export const PreferenceContent = styled.div`
   width: 100%;
   height: 41px;
 `;
+
+export const PreferenceBadge = styled.div`
+  display: flex;
+  gap: 6px;
+  align-items: center;
+
+  width: auto;
+  height: 41px;
+
+  padding: 10px 16px 10px 10px;
+
+  border-radius: 12px;
+  border: 1px solid ${COLORS.GRAYSCALE_200};
+`;

--- a/app/mypage/sports/style.ts
+++ b/app/mypage/sports/style.ts
@@ -13,6 +13,61 @@ export const PreferenceSectionWrapper = styled.div`
   height: auto;
 `;
 
+export const SportsPreferenceWrapper = styled.div<{
+  $isHeightFull?: boolean;
+}>`
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  color: ${COLORS.GRAYSCALE_900};
+  flex-grow: ${({ $isHeightFull = true }) => ($isHeightFull ? "1" : "auto")};
+  padding: 48px 20px 0px 20px;
+  box-sizing: border-box;
+
+  top: 97px;
+`;
+
+export const SignupIntroContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+export const SignupIntroTitleWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+export const InfoContainer = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  gap: 12px;
+`;
+
+export const ButtonContainer = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+
+  position: absolute;
+  bottom: 84px;
+`;
+
+export const ButtonWrapper = styled.div`
+  box-sizing: border-box;
+  width: 65px;
+`;
+
+export const TextButtonWrapper = styled.div`
+  display: flex;
+  gap: 10px;
+  width: 100%;
+  white-space: nowrap;
+  flex-wrap: wrap;
+`;
+
 export const PreferenceHeader = styled.div`
   display: flex;
   justify-content: space-between;
@@ -57,18 +112,4 @@ export const PreferenceContent = styled.div`
 
   width: 100%;
   height: 41px;
-`;
-
-export const PreferenceBadge = styled.div`
-  display: flex;
-  gap: 6px;
-  align-items: center;
-
-  width: auto;
-  height: 41px;
-
-  padding: 10px 16px 10px 10px;
-
-  border-radius: 12px;
-  border: 1px solid ${COLORS.GRAYSCALE_200};
 `;

--- a/app/mypage/sports/style.ts
+++ b/app/mypage/sports/style.ts
@@ -18,13 +18,21 @@ export const SportsPreferenceWrapper = styled.div<{
 }>`
   display: flex;
   flex-direction: column;
+  flex-grow: 1;
+
+  overflow-y: auto;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+
   gap: 32px;
   color: ${COLORS.GRAYSCALE_900};
   flex-grow: ${({ $isHeightFull = true }) => ($isHeightFull ? "1" : "auto")};
   padding: 48px 20px 0px 20px;
   box-sizing: border-box;
-
-  top: 97px;
 `;
 
 export const SignupIntroContainer = styled.div`
@@ -48,11 +56,12 @@ export const InfoContainer = styled.div`
 export const ButtonContainer = styled.div`
   display: flex;
   width: 100%;
+  max-width: 410px;
   justify-content: center;
   align-items: center;
+  margin-top: auto;
 
-  position: absolute;
-  bottom: 84px;
+  padding: 12px 0px 20px 0px;
 `;
 
 export const ButtonWrapper = styled.div`

--- a/app/mypage/sports/style.ts
+++ b/app/mypage/sports/style.ts
@@ -18,7 +18,6 @@ export const SportsPreferenceWrapper = styled.div<{
 }>`
   display: flex;
   flex-direction: column;
-  flex-grow: 1;
 
   overflow-y: auto;
 

--- a/app/mypage/style.ts
+++ b/app/mypage/style.ts
@@ -292,7 +292,11 @@ export const ButtonWrapper = styled.div`
   margin-top: 15px;
 `;
 
-export const PrimaryButton = styled.button`
+export const SkillLevelInfo = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
   padding: 8px 10px;
   width: 68px;
   height: 34px;
@@ -309,7 +313,6 @@ export const PrimaryButton = styled.button`
   background-color: ${COLORS.BLUE_50};
   border: none;
   border-radius: 10px;
-  cursor: pointer;
 `;
 
 export const SecondaryButton = styled.button`

--- a/app/mypage/style.ts
+++ b/app/mypage/style.ts
@@ -17,6 +17,30 @@ export const PageContainer = styled.div`
   }
 `;
 
+export const ProfileContainerWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+`;
+
+export const ProfileHeaderWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const ProfileNameInfoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 2px;
+`;
+
 export const ProfileOverviewWrapper = styled.div`
   display: flex;
   flex-direction: column;
@@ -38,13 +62,15 @@ export const PreferenceFacilityWrapper = styled.div`
 `;
 
 export const ProfileSection = styled.section<{ $isEditingProfile: boolean }>`
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
+  gap: 24px;
 
   width: 100%;
   height: auto;
-  max-height: 300px;
+
   padding: 12px 0px 32px 0px;
   box-sizing: border-box;
   background-color: #ffffff;
@@ -203,7 +229,7 @@ export const InfoSection = styled.section`
   font-size: 12px;
   color: #888888;
   background-color: #ffffff;
-  padding: 12px 20px;
+  padding: 12px 20px 30px 20px;
   box-sizing: border-box;
 
   width: 100%;
@@ -276,7 +302,6 @@ export const PrimaryButton = styled.button`
   padding: 8px 10px;
   width: 68px;
   height: 34px;
-  margin-top: 16px;
 
   font-size: 12px;
   font-weight: 600;
@@ -345,7 +370,7 @@ export const ProfileImageWrapper = styled.div<{ $isEditingProfile: boolean }>`
 
   border-radius: 50%;
 
-  border: 1px solid gray;
+  border: 2px solid ${COLORS.GRAYSCALE_100};
 
   overflow: hidden;
 
@@ -361,4 +386,21 @@ export const ProfileImageWrapper = styled.div<{ $isEditingProfile: boolean }>`
       opacity: 1; 
     }
   `}
+`;
+
+export const DumbberIconWrapper = styled.div`
+  position: absolute;
+  top: 60px;
+  right: calc(50% - 38px);
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  background-color: #004dff;
+
+  width: 28px;
+  height: 28px;
+
+  border-radius: 50%;
 `;

--- a/app/mypage/style.ts
+++ b/app/mypage/style.ts
@@ -208,12 +208,6 @@ export const ManagementSection = styled.section`
 
   width: 100%;
   height: 432px;
-  max-height: 432px;
-
-  overflow-y: scroll;
-  &::-webkit-scrollbar {
-    display: none;
-  }
 
   padding: 0px 20px;
   box-sizing: border-box;
@@ -403,4 +397,12 @@ export const DumbberIconWrapper = styled.div`
   height: 28px;
 
   border-radius: 50%;
+`;
+
+export const UnderlinedWrapper = styled.div`
+  width: auto;
+  height: auto;
+  border-bottom: 0.5px solid #adb3c2;
+
+  gap: 8px;
 `;

--- a/app/mypage/time/Time.tsx
+++ b/app/mypage/time/Time.tsx
@@ -1,15 +1,15 @@
 "use client";
 
 import { Typography } from "@/components/atoms/Typography";
-import React from "react";
-import * as S from "./style";
+import { TIME_MAPPING } from "@/constants/Time";
+import { useMyPageInfo } from "@/hooks/queries/useMypageInfo";
 import Link from "next/link";
+import * as S from "./style";
 
-interface TimeProps {
-  preferences: string[];
-}
+export default function Time() {
+  const { data: userInfo } = useMyPageInfo();
 
-export default function Time({ preferences}: TimeProps) {
+  const preferenceKey = userInfo?.preferredWorkoutTime;
   return (
     <S.PreferenceTimeWrapper>
       <S.PreferenceHeader>
@@ -24,7 +24,9 @@ export default function Time({ preferences}: TimeProps) {
         </Link>
       </S.PreferenceHeader>
       <S.PreferenceTime>
-        <S.PreferenceTimeTitle>주말 아침</S.PreferenceTimeTitle>
+        <S.PreferenceTimeTitle>
+          {preferenceKey ? TIME_MAPPING[preferenceKey] : "선호 시간 없음"}
+        </S.PreferenceTimeTitle>
         <S.PreferenceTimeRange>오전 9시 ~ 오전 11시</S.PreferenceTimeRange>
       </S.PreferenceTime>
     </S.PreferenceTimeWrapper>

--- a/app/mypage/time/Time.tsx
+++ b/app/mypage/time/Time.tsx
@@ -1,12 +1,23 @@
 "use client";
 
+import AfternoonIcon from "@/assets/images/afternoon.svg";
+import EveningIcon from "@/assets/images/evening.svg";
+import MorningIcon from "@/assets/images/morning.svg";
 import { Typography } from "@/components/atoms/Typography";
 import { TIME_MAPPING } from "@/constants/Time";
 import { useMyPageInfo } from "@/hooks/queries/useMypageInfo";
+import getTimeSlot from "@/utils/getTimeSlot";
 import Link from "next/link";
+import { JSX } from "react";
 import * as S from "./style";
 
 export default function Time() {
+  const iconMapping: Record<string, JSX.Element> = {
+    morning: <MorningIcon />,
+    afternoon: <AfternoonIcon />,
+    evening: <EveningIcon />,
+  };
+
   const { data: userInfo } = useMyPageInfo();
 
   const preferenceKey = userInfo?.preferredWorkoutTime;
@@ -24,10 +35,16 @@ export default function Time() {
         </Link>
       </S.PreferenceHeader>
       <S.PreferenceTime>
-        <S.PreferenceTimeTitle>
-          {preferenceKey ? TIME_MAPPING[preferenceKey] : "선호 시간 없음"}
-        </S.PreferenceTimeTitle>
-        <S.PreferenceTimeRange>오전 9시 ~ 오전 11시</S.PreferenceTimeRange>
+        {userInfo?.preferredWorkoutTime ? (
+          <>
+            {iconMapping[getTimeSlot(userInfo.preferredWorkoutTime)]}
+            <Typography.H4Md color="#27282D" style={{ marginLeft: "8px" }}>
+              {TIME_MAPPING[userInfo.preferredWorkoutTime]}
+            </Typography.H4Md>
+          </>
+        ) : (
+          <Typography.H4Md color="#27282D">미설정</Typography.H4Md>
+        )}
       </S.PreferenceTime>
     </S.PreferenceTimeWrapper>
   );

--- a/app/mypage/time/page.tsx
+++ b/app/mypage/time/page.tsx
@@ -44,9 +44,36 @@ const TimePreference = () => {
       return await setTimePreference({
         preferredWorkoutTime: selectedTimes,
         favoriteWorkouts:
-          userInfo?.favoriteWorkouts.map((w: WorkoutType) => w.code) ?? null,
+          userInfo?.favoriteWorkouts?.map((w: WorkoutType) => w.code) ?? null,
         favoritePlaces: userInfo?.favoritePlaces ?? null,
       });
+    },
+
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: ["myPageInfo"] });
+
+      const previousData = queryClient.getQueryData(["myPageInfo"]);
+
+      queryClient.setQueryData(["myPageInfo"], (oldData: any) => {
+        if (!oldData) return oldData;
+        return {
+          ...oldData,
+          preferredWorkoutTime: selectedTimes,
+          favoriteWorkouts:
+            oldData.favoriteWorkouts?.map((w: WorkoutType) => w.code) ?? null,
+          favoritePlaces: oldData.favoritePlaces ?? null,
+        };
+      });
+
+      return { previousData };
+    },
+
+    onError: (error, _variables, context) => {
+      if (context?.previousData) {
+        queryClient.setQueryData(["myPageInfo"], context.previousData);
+      }
+      console.error(error);
+      alert("운동 선호 정보를 수정하는데 실패했습니다.");
     },
 
     onSuccess: async () => {
@@ -55,10 +82,6 @@ const TimePreference = () => {
       if (isMypageTime) {
         router.back();
       }
-    },
-
-    onError: (error) => {
-      console.error(error);
     },
   });
 

--- a/app/mypage/time/page.tsx
+++ b/app/mypage/time/page.tsx
@@ -1,18 +1,136 @@
 "use client";
 
+import { WorkoutType } from "@/app/mypage/sports/page";
+import AfternoonIcon from "@/assets/images/afternoon.svg";
+import EveningIcon from "@/assets/images/evening.svg";
+import MorningIcon from "@/assets/images/morning.svg";
+import { Typography } from "@/components/atoms/Typography";
+import Button from "@/components/common/Button";
 import Header from "@/components/common/Header/Header";
-import { SIGNUP_STEPS } from "@/constants/Signup";
-import { Container } from "@mui/material";
-import React, { useState } from "react";
-import SignupForm from "@/components/auth/signup/SignupForm";
+import TextButton from "@/components/common/TextButton";
+import { BUTTON_SIZES, BUTTON_VARIANTS } from "@/constants/Button";
+import { TIME_PREFERENCES } from "@/constants/Signup";
+import { COLORS } from "@/constants/Theme";
+import { usePathname, useRouter } from "next/navigation";
+import { useState } from "react";
+import * as S from "./style";
 
-export default function Page() {
-  const [step, setStep] = useState<number>(SIGNUP_STEPS[4].id);
+import { useMyPageInfo } from "@/hooks/queries/useMypageInfo";
+import { setTimePreference } from "@/services/mypage/setTimePreference";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+const ICONS = {
+  MorningIcon: <MorningIcon />,
+  AfternoonIcon: <AfternoonIcon />,
+  EveningIcon: <EveningIcon />,
+};
+
+const TimePreference = () => {
+  const [selectedTimes, setSelectedTimes] = useState<string>("");
+  const { data: userInfo } = useMyPageInfo();
+
+  const router = useRouter();
+  const pathname = usePathname();
+  const queryClient = useQueryClient();
+  const isMypageTime = pathname === "/mypage/time";
+  const isSignup = pathname === "/auth/signup";
+
+  const handleTimeClick = (timeKey: string) => {
+    setSelectedTimes(timeKey);
+  };
+
+  const { mutate: updateTimePreference } = useMutation({
+    mutationFn: async () => {
+      return await setTimePreference({
+        preferredWorkoutTime: selectedTimes,
+        favoriteWorkouts:
+          userInfo?.favoriteWorkouts.map((w: WorkoutType) => w.code) ?? null,
+        favoritePlaces: userInfo?.favoritePlaces ?? null,
+      });
+    },
+
+    onSuccess: async () => {
+      await queryClient.refetchQueries({ queryKey: ["myPageInfo"] });
+
+      if (isMypageTime) {
+        router.back();
+      }
+    },
+
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+
+  const buttonClickHandler = () => {
+    if (selectedTimes) {
+      updateTimePreference();
+    }
+  };
 
   return (
     <>
       <Header />
-      <SignupForm step={step} setStep={setStep} />
+      <S.TimePreferenceContainer $isHeightFull={!isSignup}>
+        <S.TimePreferenceWrapper>
+          <S.SignupIntroContainer>
+            <S.SignupIntroTitleWrapper>
+              <Typography.H1Sb>선호하는</Typography.H1Sb>
+              <Typography.H1Sb>
+                <span style={{ color: COLORS.BLUE_500 }}>운동 시간대</span>를
+                선택해주세요!
+              </Typography.H1Sb>
+            </S.SignupIntroTitleWrapper>
+            <Typography.H4Md color={COLORS.GRAYSCALE_600}>
+              "메이트 매칭 시 필요한 정보에요."
+            </Typography.H4Md>
+          </S.SignupIntroContainer>
+          <S.InfoWrapper>
+            <S.InfoContainer>
+              <Typography.H4Sb>평일</Typography.H4Sb>
+              <S.TextButtonWrapper>
+                {TIME_PREFERENCES.WEEKDAY.map(({ key, label, icon }) => (
+                  <TextButton
+                    key={label}
+                    icon={ICONS[icon]}
+                    isActive={selectedTimes === key}
+                    onClick={() => handleTimeClick(key)}
+                  >
+                    {label}
+                  </TextButton>
+                ))}
+              </S.TextButtonWrapper>
+            </S.InfoContainer>
+            <S.InfoContainer>
+              <Typography.H4Sb>주말</Typography.H4Sb>
+              <S.TextButtonWrapper>
+                {TIME_PREFERENCES.WEEKEND.map(({ key, label, icon }) => (
+                  <TextButton
+                    key={label}
+                    icon={ICONS[icon]}
+                    isActive={selectedTimes === key}
+                    onClick={() => handleTimeClick(key)}
+                  >
+                    {label}
+                  </TextButton>
+                ))}
+              </S.TextButtonWrapper>
+            </S.InfoContainer>
+          </S.InfoWrapper>
+        </S.TimePreferenceWrapper>
+        <S.ButtonContainer>
+          <Button
+            disabled={!selectedTimes}
+            size={BUTTON_SIZES.LARGE}
+            variant={BUTTON_VARIANTS.PRIMARY}
+            onClick={buttonClickHandler}
+          >
+            변경 완료
+          </Button>
+        </S.ButtonContainer>
+      </S.TimePreferenceContainer>
     </>
   );
-}
+};
+
+export default TimePreference;

--- a/app/mypage/time/page.tsx
+++ b/app/mypage/time/page.tsx
@@ -12,7 +12,7 @@ import { BUTTON_SIZES, BUTTON_VARIANTS } from "@/constants/Button";
 import { TIME_PREFERENCES } from "@/constants/Signup";
 import { COLORS } from "@/constants/Theme";
 import { usePathname, useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import * as S from "./style";
 
 import { useMyPageInfo } from "@/hooks/queries/useMypageInfo";
@@ -90,6 +90,12 @@ const TimePreference = () => {
       updateTimePreference();
     }
   };
+
+  useEffect(() => {
+    if (userInfo?.preferredWorkoutTime) {
+      setSelectedTimes(userInfo.preferredWorkoutTime);
+    }
+  }, [userInfo]);
 
   return (
     <>

--- a/app/mypage/time/style.ts
+++ b/app/mypage/time/style.ts
@@ -118,16 +118,19 @@ export const PreferenceTimeWrapper = styled.div`
 
 export const PreferenceTime = styled.div`
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  justify-content: center;
+  align-items: center;
 
-  width: 100%;
-  height: 73px;
+  width: auto;
+  max-width: 120px;
+  height: 45px;
 
-  padding: 16px 20px;
+  gap: 4px;
+
+  padding: 12px 20px 12px 16px;
   box-sizing: border-box;
 
-  border-radius: 16px;
+  border-radius: 12px;
   border: 1px solid ${COLORS.GRAYSCALE_200};
 `;
 

--- a/app/mypage/time/style.ts
+++ b/app/mypage/time/style.ts
@@ -1,13 +1,72 @@
 import { COLORS } from "@/constants/Theme";
 import styled from "styled-components";
 
-export const PreferenceSectionWrapper = styled.div`
+export const TimePreferenceContainer = styled.div<{
+  $isHeightFull?: boolean;
+}>`
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 36px;
+  height: ${({ $isHeightFull = true }) => ($isHeightFull ? "100%" : "auto")};
+
+  padding: 48px 20px 0px 20px;
+  box-sizing: border-box;
+
+  align-items: center;
+`;
+
+export const TimePreferenceWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  color: ${COLORS.GRAYSCALE_900};
+  flex-grow: 1;
 
   width: 100%;
-  height: auto;
+`;
+
+export const SignupIntroContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+export const SignupIntroTitleWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+export const InfoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+`;
+
+export const InfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 12px;
+`;
+
+export const ButtonContainer = styled.div`
+  display: flex;
+  width: 100%;
+  max-width: 410px;
+  justify-content: center;
+  align-items: center;
+  margin-top: auto;
+
+  padding: 12px 0px 20px 0px;
+`;
+
+export const TextButtonWrapper = styled.div`
+  display: flex;
+  width: 100%;
+  gap: 10px;
+  color: ${COLORS.GRAYSCALE_600};
+  white-space: nowrap;
 `;
 
 export const PreferenceHeader = styled.div`

--- a/components/auth/signup/steps/SportsPreference/SportsPreference.tsx
+++ b/components/auth/signup/steps/SportsPreference/SportsPreference.tsx
@@ -1,13 +1,13 @@
-import { StepProps } from "@/types/step";
 import { Typography } from "@/components/atoms/Typography";
-import { COLORS } from "@/constants/Theme";
 import Button from "@/components/common/Button";
-import * as S from "./SportsPreference.style";
+import TextButton from "@/components/common/TextButton";
 import { BUTTON_SIZES, BUTTON_VARIANTS } from "@/constants/Button";
 import { SPORTS_LABEL, STEPS_LABEL } from "@/constants/Signup";
+import { COLORS } from "@/constants/Theme";
+import { StepProps } from "@/types/step";
 import { usePathname, useRouter } from "next/navigation";
 import { useState } from "react";
-import TextButton from "@/components/common/TextButton";
+import * as S from "./SportsPreference.style";
 
 const SportsPreference = ({ nextStep }: StepProps) => {
   const [selectedSports, setSelectedSports] = useState<string[]>([]);

--- a/components/common/Button/index.tsx
+++ b/components/common/Button/index.tsx
@@ -11,6 +11,7 @@ interface ButtonProps {
   variant?: (typeof BUTTON_VARIANTS)[keyof typeof BUTTON_VARIANTS];
   icon?: React.ReactNode;
   onClick?: () => void;
+  style?: React.CSSProperties;
 }
 
 const Button = ({
@@ -19,6 +20,7 @@ const Button = ({
   variant,
   icon,
   onClick,
+  style,
   children,
 }: ButtonProps) => {
   return (
@@ -27,6 +29,7 @@ const Button = ({
       $variant={variant}
       $disabled={disabled}
       onClick={onClick}
+      style={style}
     >
       {icon && <S.IconWrapper>{icon}</S.IconWrapper>}
       {children}

--- a/components/common/SelectBar/SelectBar.tsx
+++ b/components/common/SelectBar/SelectBar.tsx
@@ -62,7 +62,15 @@ export default function SelectBar<T extends string | number>({
         style={{ ...boxStyle }}
       >
         <div style={{ width: "73px" }}>
-          <Typography.H4Md>{optionValue}</Typography.H4Md>
+          <Typography.H4Md
+            color={
+              optionValue !== "오전/오후" && optionValue !== "00시"
+                ? COLORS.GRAYSCALE_900
+                : COLORS.GRAYSCALE_600
+            }
+          >
+            {optionValue}
+          </Typography.H4Md>
         </div>
         {hasSuffix && suffixText && (
           <Typography.H4Md color="#545862">{suffixText}</Typography.H4Md>

--- a/hooks/queries/usePlacesSearch.ts
+++ b/hooks/queries/usePlacesSearch.ts
@@ -1,0 +1,15 @@
+// hooks/queries/usePlacesSearch.ts
+import { useDebounce } from "@/hooks/useDebounce";
+import { getPlacesBySearch } from "@/services/mypage/getPlaceBySearch";
+import { useQuery } from "@tanstack/react-query";
+
+export function usePlacesSearch(searchTerm: string) {
+  const debouncedSearch = useDebounce(searchTerm, 300);
+
+  return useQuery({
+    queryKey: ["facilityPlaces", debouncedSearch],
+    queryFn: () => getPlacesBySearch(debouncedSearch),
+    enabled: !!debouncedSearch,
+    initialData: [],
+  });
+}

--- a/services/mate/searchMate.ts
+++ b/services/mate/searchMate.ts
@@ -1,5 +1,5 @@
 import { useTokenStore } from "@/stores/tokenStore";
-import axios from "axios";
+import { api } from "../axiosInterceptor";
 
 interface MateApiResponse {
   message: string;
@@ -56,7 +56,7 @@ export async function fetchMates({
     const preferredTimesParam = preferredTimes?.join(",");
     const workoutTypesParam = workoutTypes?.join(",");
 
-    const { data } = await axios.get<MateApiResponse>(
+    const { data } = await api<MateApiResponse>(
       `${process.env.NEXT_PUBLIC_BASE_URL}/v1/users/mates`,
       {
         params: {
@@ -67,10 +67,6 @@ export async function fetchMates({
           page: pageParam,
           size,
         },
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-        withCredentials: true,
       },
     );
     console.log("✅ API 응답 성공:", data);

--- a/services/mypage/getMypageInfo.ts
+++ b/services/mypage/getMypageInfo.ts
@@ -1,5 +1,6 @@
 import { useTokenStore } from "@/stores/tokenStore";
-import axios from "axios";
+
+import { api } from "../axiosInterceptor";
 
 export const getMypageInfo = async () => {
   try {
@@ -10,7 +11,7 @@ export const getMypageInfo = async () => {
       throw new Error("Unauthorized");
     }
 
-    const response = await axios.get(
+    const response = await api(
       `${process.env.NEXT_PUBLIC_BASE_URL}/v1/users/me`,
       {
         headers: {

--- a/services/mypage/getMypageInfo.ts
+++ b/services/mypage/getMypageInfo.ts
@@ -1,5 +1,4 @@
 import { useTokenStore } from "@/stores/tokenStore";
-
 import { api } from "../axiosInterceptor";
 
 export const getMypageInfo = async () => {
@@ -13,12 +12,6 @@ export const getMypageInfo = async () => {
 
     const response = await api(
       `${process.env.NEXT_PUBLIC_BASE_URL}/v1/users/me`,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-        withCredentials: true,
-      },
     );
 
     return response.data.data;

--- a/services/mypage/getPlaceBySearch.ts
+++ b/services/mypage/getPlaceBySearch.ts
@@ -1,0 +1,29 @@
+import { api } from "../axiosInterceptor";
+
+interface PlacesResponse {
+  data: {
+    addressName: string;
+    roadAddressName: string;
+    placeName: string;
+    distance: number;
+  }[];
+  message: string;
+}
+
+export async function getPlacesBySearch(query: string) {
+  if (!query) return [];
+
+  try {
+    const response = await api<PlacesResponse>(
+      `${process.env.NEXT_PUBLIC_BASE_URL}/v1/regions/places`,
+      {
+        params: { q: query },
+      },
+    );
+
+    return response.data?.data ?? [];
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+}

--- a/services/mypage/setFacilityPreferences.ts
+++ b/services/mypage/setFacilityPreferences.ts
@@ -1,0 +1,22 @@
+import { api } from "../axiosInterceptor";
+
+export interface FacilityPreferencesPayload {
+  preferredWorkoutTime: string | null;
+  favoriteWorkouts: string[] | null;
+  favoritePlaces:
+    | {
+        placeName: string;
+        address: string;
+      }[]
+    | null;
+}
+
+export async function setFacilityPreference(
+  payload: FacilityPreferencesPayload,
+) {
+  const { data } = await api.put(
+    `${process.env.NEXT_PUBLIC_BASE_URL}/v1/users/me/workout-preferences`,
+    payload,
+  );
+  return data;
+}

--- a/services/mypage/setTimePreference.ts
+++ b/services/mypage/setTimePreference.ts
@@ -1,0 +1,20 @@
+import { api } from "../axiosInterceptor";
+
+export interface TimePreferencesPayload {
+  preferredWorkoutTime: string | null;
+  favoriteWorkouts: string[] | null;
+  favoritePlaces:
+    | {
+        placeName: string;
+        address: string;
+      }[]
+    | null;
+}
+
+export async function setTimePreference(payload: TimePreferencesPayload) {
+  const { data } = await api.put(
+    `${process.env.NEXT_PUBLIC_BASE_URL}/v1/users/me/workout-preferences`,
+    payload,
+  );
+  return data;
+}

--- a/services/mypage/setWorkoutPreferences.ts
+++ b/services/mypage/setWorkoutPreferences.ts
@@ -1,0 +1,22 @@
+import { api } from "../axiosInterceptor";
+
+export interface WorkoutPreferencesPayload {
+  preferredWorkoutTime: string | null;
+  favoriteWorkouts: string[] | null;
+  favoritePlaces:
+    | {
+        placeName: string;
+        address: string;
+      }[]
+    | null;
+}
+
+export async function setWorkoutPreferences(
+  payload: WorkoutPreferencesPayload,
+) {
+  const { data } = await api.put(
+    `${process.env.NEXT_PUBLIC_BASE_URL}/v1/users/me/workout-preferences`,
+    payload,
+  );
+  return data;
+}

--- a/utils/getTimeSlot.ts
+++ b/utils/getTimeSlot.ts
@@ -1,0 +1,8 @@
+export default function getTimeSlot(
+  timeKey: string,
+): "morning" | "afternoon" | "evening" | "" {
+  if (timeKey.includes("MORNING")) return "morning";
+  if (timeKey.includes("AFTERNOON")) return "afternoon";
+  if (timeKey.includes("EVENING")) return "evening";
+  return "";
+}


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

![image](https://github.com/user-attachments/assets/6ef1b36d-f563-4933-8ad0-b236e1608fe1)<br>

![image](https://github.com/user-attachments/assets/3cf0a0b8-ea4c-4bd0-a711-df8bdfcb6a1c)<br>

![image](https://github.com/user-attachments/assets/4d3c4bc9-4030-4a15-830e-ea13cdd216df)<br>




## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {Jira 이슈 키}를 입력해주세요. <br>
close SCRUM-33
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [x] 기존에 tanstack-query가 적용되지 않았던 마이페이지 부분도 tanstack-query를 활용하도록 수정 및 구현 했습니다.
- [x] 선호 운동 편집은 refetchQueries와 Optimistic Update를 적용하여 mypageInfo를 사용하는 페이지, 컴포넌트의 실시간 데이터 동기화와 API 오류가 날 경우 이전 데이터로 Rollback 하도록 구현했습니다. 
➡️ **어제 말씀드린 것 처럼 하정님 쪽 태스크인 기본정보 편집에서도 데이터가 동기화 되도록 하는게 좋을거같아요!!(지금은 새로고침 해야 마운트 되면서 반영됩니다.)**
- [x] 3월 5일에 수연님이 말해주셨던 QA 반영했습니다. 

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙을 잘 지켰는가? (예: [PIJV-이슈번호] 작업 내용)
- [x] 추가/수정사항을 설명하였는가?
- [x] Jira 이슈 키를 정확히 입력했는가?
- [x] Approve 하기 전 확인 사항 체크했는가?
