### PR TITLE
SCRUM-52 / 선호운동 시설 편집 QA

### DIFF
--- a/app/mate/facility/page.tsx
+++ b/app/mate/facility/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import OurfitLogo from "@/assets/images/ourfit-logo.svg";
 import { Typography } from "@/components/atoms/Typography";
 import * as TS from "@/components/auth/signup/steps/TimePreference/TimePreference.style";
 import Button from "@/components/common/Button";
@@ -10,28 +9,20 @@ import { BUTTON_SIZES, BUTTON_VARIANTS } from "@/constants/Button";
 import { COLORS } from "@/constants/Theme";
 import { useMateInfo } from "@/hooks/queries/useMateInfo";
 
+import DefaultProfileImg from "@/components/common/DefaultProfileImg/DefaultProfileImg";
 import { queryClient } from "@/components/common/ReactQueryProvider";
+import { usePlacesSearch } from "@/hooks/queries/usePlacesSearch";
 import { useUpdateMatePlace } from "@/hooks/queries/useUpdateMatePlace";
-import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import * as S from "./style";
-import DefaultProfileImg from "@/components/common/DefaultProfileImg/DefaultProfileImg";
 
 interface FacilityItem {
-  id: string;
-  name: string;
-  address: string;
-}
-
-interface KakaoPlaceResponse {
-  documents: {
-    id: string;
-    place_name: string;
-    road_address_name?: string;
-    address_name?: string;
-  }[];
+  addressName: string;
+  roadAddressName: string;
+  placeName: string;
+  distance: number;
 }
 
 export default function SportFacility() {
@@ -39,7 +30,6 @@ export default function SportFacility() {
   const [selectedFacility, setSelectedFacility] = useState<FacilityItem | null>(
     null,
   );
-  const [debouncedValue, setDebouncedValue] = useState(facilityValue);
 
   const router = useRouter();
 
@@ -47,45 +37,15 @@ export default function SportFacility() {
   const mateId = mateInfo?.mateId;
   const { mutate: updatePlaceMutate } = useUpdateMatePlace(mateId);
 
-  useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      setDebouncedValue(facilityValue);
-    }, 1000);
-    return () => clearTimeout(timeoutId);
-  }, [facilityValue]);
-
-  const {
-    data: searchData,
-    isLoading: isSearchLoading,
-    error: searchError,
-  } = useQuery<KakaoPlaceResponse, Error>({
-    queryKey: ["kakaoPlaceSearch", debouncedValue],
-    queryFn: async () => {
-      const res = await fetch(
-        `/api/kakaoPlaceSearch?query=${encodeURIComponent(debouncedValue)}`,
-      );
-      if (!res.ok) {
-        throw new Error(`API 요청 실패: ${res.status}`);
-      }
-      return res.json();
-    },
-    enabled: !!debouncedValue.trim(),
-  });
-
-  const searchResults: FacilityItem[] =
-    searchData?.documents?.map((doc: any) => ({
-      id: doc.id,
-      name: doc.place_name,
-      address: doc.road_address_name || doc.address_name,
-    })) || [];
+  const { data: searchResults } = usePlacesSearch(facilityValue);
 
   const handleSelectFacility = (facility: FacilityItem) => {
     setSelectedFacility(facility);
 
     updatePlaceMutate(
       {
-        placeName: facility.name,
-        address: facility.address,
+        placeName: facility.placeName,
+        address: facility.addressName,
       },
       {
         onSuccess: async () => {
@@ -146,16 +106,16 @@ export default function SportFacility() {
         <S.ResultList>
           {searchResults.map((result) => (
             <S.ResultItem
-              key={result.id}
+              key={result.placeName}
               onClick={() => handleSelectFacility(result)}
             >
               <S.ImageWrapper>
                 <DefaultProfileImg size={20} />
               </S.ImageWrapper>
               <S.FacilityInfo>
-                <Typography.H4Sb>{result.name}</Typography.H4Sb>
+                <Typography.H4Sb>{result.placeName}</Typography.H4Sb>
                 <Typography.H5Md color="#8A92A3">
-                  {result.address}
+                  {result.addressName}
                 </Typography.H5Md>
               </S.FacilityInfo>
             </S.ResultItem>

--- a/app/mate/time/page.tsx
+++ b/app/mate/time/page.tsx
@@ -3,6 +3,7 @@
 import { Typography } from "@/components/atoms/Typography";
 import Button from "@/components/common/Button";
 import Header from "@/components/common/Header/Header";
+import { queryClient } from "@/components/common/ReactQueryProvider";
 import SelectBar from "@/components/common/SelectBar/SelectBar";
 import { BUTTON_SIZES, BUTTON_VARIANTS } from "@/constants/Button";
 import { COLORS } from "@/constants/Theme";
@@ -81,7 +82,8 @@ export default function SportTime() {
         endAt: parsedEndTime,
       },
       {
-        onSuccess: () => {
+        onSuccess: async () => {
+          await queryClient.invalidateQueries({ queryKey: ["mateInfo"] });
           router.push("/mate");
         },
         onError: (err: Error) => {

--- a/app/mypage/_components/EditProfile.tsx
+++ b/app/mypage/_components/EditProfile.tsx
@@ -69,7 +69,7 @@ export default function EditProfile({
       });
       await fetchUserInfo();
       if (userData?.id) {
-        await queryClient.invalidateQueries({
+        queryClient.invalidateQueries({
           queryKey: ["mateDetail", userData?.id],
           refetchType: "all",
         });

--- a/app/mypage/_components/EditProfile.tsx
+++ b/app/mypage/_components/EditProfile.tsx
@@ -69,9 +69,9 @@ export default function EditProfile({
       });
       await fetchUserInfo();
       if (userData?.id) {
-        await queryClient.refetchQueries({
+        await queryClient.invalidateQueries({
           queryKey: ["mateDetail", userData?.id],
-          exact: true,
+          refetchType: "all",
         });
       }
     } catch (error) {

--- a/app/mypage/_components/EditProfile.tsx
+++ b/app/mypage/_components/EditProfile.tsx
@@ -61,7 +61,7 @@ export default function EditProfile({
     try {
       const introductionValue = introduction?.trim() || null;
 
-      const openChatUrlValue = openChatUrl.trim() || null;
+      const openChatUrlValue = openChatUrl?.trim() || null;
 
       await updateUserProfile({
         introduction: introductionValue,

--- a/app/mypage/facility/FacilitySearch.tsx
+++ b/app/mypage/facility/FacilitySearch.tsx
@@ -116,10 +116,13 @@ export default function FacilitySearch() {
     },
 
     onSuccess: async () => {
-      await queryClient.refetchQueries({ queryKey: ["myPageInfo"] });
-      await queryClient.refetchQueries({
+      await queryClient.invalidateQueries({
+        queryKey: ["myPageInfo"],
+        refetchType: "all",
+      });
+      await queryClient.invalidateQueries({
         queryKey: ["mateDetail", userInfo?.id],
-        exact: true,
+        refetchType: "all",
       });
       addIsEdit(true);
       router.back();

--- a/app/mypage/facility/FacilitySearch.tsx
+++ b/app/mypage/facility/FacilitySearch.tsx
@@ -141,12 +141,17 @@ export default function FacilitySearch() {
   const isMypageFacility = pathname === "/mypage/facility";
 
   const isEqual = () => {
-    if (selectedPreferenceFacilities.length !== initialValue.length)
+    if (selectedPreferenceFacilities.length !== initialValue.length) {
       return false;
-    return (
-      selectedPreferenceFacilities.sort().toString() ===
-      initialValue.sort().toString()
+    }
+    const sortedSelected = [...selectedPreferenceFacilities].sort((a, b) =>
+      a.placeName.localeCompare(b.placeName),
     );
+    const sortedInitial = [...initialValue].sort((a, b) =>
+      a.placeName.localeCompare(b.placeName),
+    );
+
+    return JSON.stringify(sortedSelected) === JSON.stringify(sortedInitial);
   };
 
   useEffect(() => {

--- a/app/mypage/openchat/page.tsx
+++ b/app/mypage/openchat/page.tsx
@@ -7,14 +7,14 @@ import { INPUT_STATUS, InputStatus } from "@/constants/InputStatus";
 import Image from "next/image";
 
 import Header from "@/components/common/Header/Header";
+import { queryClient } from "@/components/common/ReactQueryProvider";
+import Toast from "@/components/common/Toast/Toast";
+import { TOAST_MESSAGES, TOAST_STATUSES, ToastStatus } from "@/constants/Toast";
+import { useMyPageInfo } from "@/hooks/queries/useMypageInfo";
 import { updateUserProfile } from "@/services/updateUserProfile";
 import { usePathname, useRouter } from "next/navigation";
 import React, { useDeferredValue, useEffect, useRef, useState } from "react";
 import * as S from "./style";
-import { useMyPageInfo } from "@/hooks/queries/useMypageInfo";
-import { queryClient } from "@/components/common/ReactQueryProvider";
-import Toast from "@/components/common/Toast/Toast";
-import { TOAST_MESSAGES, TOAST_STATUSES, ToastStatus } from "@/constants/Toast";
 
 export default function OpenChatPage() {
   const pathname = usePathname();
@@ -74,7 +74,10 @@ export default function OpenChatPage() {
         introduction: introduction || null,
         openChatUrl: linkValue.trim() || null,
       });
-      queryClient.invalidateQueries({ queryKey: ["myPageInfo"] });
+      await queryClient.invalidateQueries({
+        queryKey: ["myPageInfo"],
+        refetchType: "all",
+      });
       setShowToast(TOAST_MESSAGES.SUCCESS);
       setToastStatus(TOAST_STATUSES.SUCCESS);
       setTimeout(() => {

--- a/app/mypage/sports/page.tsx
+++ b/app/mypage/sports/page.tsx
@@ -87,10 +87,13 @@ const SportsPreference = () => {
     },
 
     onSuccess: async () => {
-      await queryClient.refetchQueries({ queryKey: ["myPageInfo"] });
-      await queryClient.refetchQueries({
+      await queryClient.invalidateQueries({
+        queryKey: ["myPageInfo"],
+        refetchType: "all",
+      });
+      await queryClient.invalidateQueries({
         queryKey: ["mateDetail", userInfo?.id],
-        exact: true,
+        refetchType: "all",
       });
 
       addIsEdit(true);

--- a/app/mypage/time/page.tsx
+++ b/app/mypage/time/page.tsx
@@ -80,10 +80,13 @@ const TimePreference = () => {
     },
 
     onSuccess: async () => {
-      await queryClient.refetchQueries({ queryKey: ["myPageInfo"] });
-      await queryClient.refetchQueries({
+      await queryClient.invalidateQueries({
+        queryKey: ["myPageInfo"],
+        refetchType: "all",
+      });
+      await queryClient.invalidateQueries({
         queryKey: ["mateDetail", userInfo?.id],
-        exact: true,
+        refetchType: "all",
       });
 
       if (isMypageTime) {

--- a/hooks/queries/useMypageInfo.ts
+++ b/hooks/queries/useMypageInfo.ts
@@ -13,5 +13,6 @@ export function useMyPageInfo() {
     queryKey: ["myPageInfo"],
     queryFn: getMypageInfo,
     staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 10,
   });
 }

--- a/hooks/queries/usePlacesSearch.ts
+++ b/hooks/queries/usePlacesSearch.ts
@@ -1,6 +1,6 @@
 // hooks/queries/usePlacesSearch.ts
 import { useDebounce } from "@/hooks/useDebounce";
-import { getPlacesBySearch } from "@/services/mypage/getPlaceBySearch";
+import { getPlacesBySearch } from "@/services/getPlaceBySearch";
 import { useQuery } from "@tanstack/react-query";
 
 export function usePlacesSearch(searchTerm: string) {

--- a/services/getPlaceBySearch.ts
+++ b/services/getPlaceBySearch.ts
@@ -1,4 +1,4 @@
-import { api } from "../axiosInterceptor";
+import { api } from "./axiosInterceptor";
 
 interface PlacesResponse {
   data: {


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {Jira 이슈 키}를 입력해주세요. <br>
close SCRUM-52
<br>
<br>

![image](https://github.com/user-attachments/assets/b9ab7445-01ef-4018-9736-fb79b077f379)<br>
![image](https://github.com/user-attachments/assets/b3053bbe-362a-4ebf-8ceb-b4243d11a68f)<br>



## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [x] 기존 카카오맵 API를 거치는 로직을 제거하였습니다.
- [x] 현업자분 이랑 `refetchQueries` vs `invalidateQueries`에 대해서 얘기를 해보고 `invalidateQueries`로 리팩토링 하였습니다! 기존에는 같은 쿼리키를 사용하는 페이지나 컴포넌트에서 동시에 네트워크 요청함으로써 빠른 동기화가 되도록 하는것이 좋다고 판단하여 `refetchQueries`를 적용 하였습니다.  이후 대화를 해보면서 개선 방법으로 `invalidateQueries`를 활용하되 `refetchType: all`을 설정해줌으로써 컴포넌트가 언마운트 됐을때(inactive)도 쿼리 무효화가 가능하게 하고 마운트시에 빠르게 패칭하도록 리팩토링 하였습니다:)  ➡️ refetchQueries를 활용하면 동시에 네트워크 요청을 함으로써 빠른 동기화는 가능하지만 성능 상 이점이 덜 하다고 판단하였습니다. 즉, invalidateQueries를 활용하는것이 좋을 것 같다라고 의견이 모아져서 리팩토링 했습니다 ㅎㅎ

[https://no2jfamily.tistory.com/122]()

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙을 잘 지켰는가? (예: [PIJV-이슈번호] 작업 내용)
- [x] 추가/수정사항을 설명하였는가?
- [x] Jira 이슈 키를 정확히 입력했는가?
- [x] Approve 하기 전 확인 사항 체크했는가?
